### PR TITLE
feat(frontend): scale up UI — bigger cards, fonts, tighter margins

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
         width: '100%',
         background: 'var(--surface)',
         borderBottom: '4px solid var(--gold)',
-        padding: '14px 28px',
+        padding: '10px 20px',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
@@ -63,7 +63,7 @@ function App() {
       }}>
         <div style={{
           fontFamily: 'var(--font-ui)',
-          fontSize: 18,
+          fontSize: 20,
           color: 'var(--gold)',
           textShadow: '2px 2px 0 var(--gold-d)',
           letterSpacing: 3,
@@ -72,7 +72,7 @@ function App() {
         </div>
 
         <div style={{
-          fontSize: 6,
+          fontSize: 8,
           color: 'var(--gold)',
           display: 'flex',
           gap: 20,
@@ -115,7 +115,7 @@ function App() {
           }}>
             <div style={{
               fontFamily: 'var(--font-ui)',
-              fontSize: 28,
+              fontSize: 32,
               color: 'var(--gold)',
               textShadow: '0 0 20px rgba(200,160,64,0.5)',
               letterSpacing: 4,
@@ -124,7 +124,7 @@ function App() {
               CYBER HOLD'EM
             </div>
             <div style={{
-              fontSize: 7,
+              fontSize: 10,
               color: 'var(--gold-d)',
               letterSpacing: 2,
               fontFamily: 'var(--font-label)',
@@ -133,7 +133,7 @@ function App() {
             </div>
             <button
               className="abtn abtn-raise"
-              style={{ fontSize: 10, padding: '14px 28px', marginTop: 16 }}
+              style={{ fontSize: 13, padding: '16px 32px', marginTop: 16 }}
               onClick={() => startGame()}
             >
               ▶ START GAME
@@ -155,7 +155,7 @@ function App() {
 
             {/* Next hand button */}
             {isGameOver && (
-              <div style={{ padding: '8px 0 4px' }}>
+              <div style={{ padding: '10px 0 6px' }}>
                 <button
                   className="abtn abtn-raise"
                   onClick={startNextHand}

--- a/frontend/src/components/ai-coach/AICoachPanel.tsx
+++ b/frontend/src/components/ai-coach/AICoachPanel.tsx
@@ -51,7 +51,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
         marginBottom: 12,
       }}>
         <div style={{
-          fontSize: 7,
+          fontSize: 10,
           color: 'var(--gold)',
           letterSpacing: 2,
           fontFamily: 'var(--font-label)',
@@ -65,8 +65,8 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
             background: 'none',
             border: '1px solid var(--gold-d)',
             color: 'var(--gold-d)',
-            fontSize: 6,
-            padding: '2px 6px',
+            fontSize: 8,
+            padding: '3px 8px',
             cursor: 'pointer',
             fontFamily: 'var(--font-label)',
           }}
@@ -79,7 +79,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
       {isLoading && (
         <div style={{
           fontFamily: 'var(--font-ai)',
-          fontSize: 22,
+          fontSize: 24,
           color: '#c8b080',
           lineHeight: 2.1,
           minHeight: 80,
@@ -98,7 +98,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
           {/* Recommendation */}
           <div style={{
             fontFamily: 'var(--font-ui)',
-            fontSize: 12,
+            fontSize: 15,
             color: REC_COLORS[advice.recommendation] ?? 'var(--gold)',
             textShadow: advice.recommendation === 'RAISE'
               ? '0 0 8px rgba(255,204,0,0.5)'
@@ -112,7 +112,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
           {/* Body text with inline cards */}
           <div style={{
             fontFamily: 'var(--font-ai)',
-            fontSize: 22,
+            fontSize: 24,
             color: '#c8b080',
             lineHeight: 2.1,
             maxHeight: 320,
@@ -145,7 +145,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
                   textAlign: 'center',
                 }}>
                   <div style={{
-                    fontSize: 5,
+                    fontSize: 7,
                     color: 'var(--gold-d)',
                     marginBottom: 5,
                     fontFamily: 'var(--font-label)',
@@ -154,7 +154,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
                   </div>
                   <div style={{
                     fontFamily: 'var(--font-ui)',
-                    fontSize: 10,
+                    fontSize: 13,
                     color: STAT_COLORS[stat.quality] ?? 'var(--gold)',
                   }}>
                     {stat.value}
@@ -170,7 +170,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
       {!isLoading && !advice && (
         <div style={{
           fontFamily: 'var(--font-ai)',
-          fontSize: 20,
+          fontSize: 22,
           color: 'var(--gold-d)',
           textAlign: 'center',
           padding: '20px 0',

--- a/frontend/src/components/card/Card.tsx
+++ b/frontend/src/components/card/Card.tsx
@@ -27,8 +27,17 @@ interface SizeSpec {
 }
 
 const SIZES: Record<CardSize, SizeSpec> = {
-  // Dimensions from design_reference/layout_v3.html
+  // LG/SM from design_reference/card_v3.html; MD uses old LG dims for larger human hole cards
   lg: {
+    width: 74, height: 104,
+    clipPx: 6,
+    shadow: '4px 4px 0 #000',
+    rankFontSize: 24,
+    suitFontSize: 48,
+    tlTop: 6, tlLeft: 7,
+    borderWidth: 3,
+  },
+  md: {
     width: 62, height: 88,
     clipPx: 5,
     shadow: '3px 3px 0 #000',
@@ -37,22 +46,13 @@ const SIZES: Record<CardSize, SizeSpec> = {
     tlTop: 5, tlLeft: 6,
     borderWidth: 3,
   },
-  md: {
-    width: 58, height: 82,
-    clipPx: 5,
-    shadow: '3px 3px 0 #000',
-    rankFontSize: 18,
-    suitFontSize: 36,
-    tlTop: 5, tlLeft: 6,
-    borderWidth: 3,
-  },
   sm: {
-    width: 30, height: 42,
-    clipPx: 3,
-    shadow: '1px 1px 0 #000',
-    rankFontSize: 10,
-    suitFontSize: 16,
-    tlTop: 3, tlLeft: 4,
+    width: 38, height: 54,
+    clipPx: 4,
+    shadow: '2px 2px 0 #000',
+    rankFontSize: 13,
+    suitFontSize: 22,
+    tlTop: 4, tlLeft: 5,
     borderWidth: 2,
   },
   xs: {
@@ -132,7 +132,7 @@ const Card: React.FC<CardProps> = ({
           display: 'flex', alignItems: 'center', justifyContent: 'center',
         }}>
           <span style={{
-            fontSize: size === 'lg' ? 22 : size === 'md' ? 22 : 12,
+            fontSize: size === 'lg' ? 28 : size === 'md' ? 22 : 14,
             color: '#2a4a2a',
             fontFamily: 'Georgia, serif',
             fontWeight: 900,

--- a/frontend/src/components/layout/ActionBar.tsx
+++ b/frontend/src/components/layout/ActionBar.tsx
@@ -44,12 +44,12 @@ const ActionBar: React.FC<ActionBarProps> = ({
   return (
     <div style={{
       width: '100%',
-      maxWidth: 960,
+      maxWidth: 1100,
       display: 'flex',
-      gap: 8,
+      gap: 10,
       justifyContent: 'center',
       flexWrap: 'wrap',
-      padding: '16px 16px 10px',
+      padding: '12px 8px 8px',
     }}>
       {/* FOLD */}
       <button
@@ -98,11 +98,11 @@ const ActionBar: React.FC<ActionBarProps> = ({
           />
           {/* Fix 8: min~max range hint */}
           <div style={{
-            fontSize: 5,
+            fontSize: 7,
             color: 'var(--gold-d)',
             fontFamily: 'var(--font-label)',
             textAlign: 'center',
-            width: 80,
+            width: 110,
             alignSelf: 'center',
           }}>
             {minRaise}~{maxRaise}

--- a/frontend/src/components/layout/LLMConfigBar.tsx
+++ b/frontend/src/components/layout/LLMConfigBar.tsx
@@ -17,17 +17,17 @@ const ENGINE_OPTIONS: { value: LLMEngine; label: string }[] = [
 
 const selectStyle: React.CSSProperties = {
   fontFamily: 'var(--font-label)',
-  fontSize: 5,
+  fontSize: 7,
   background: '#000',
   border: '2px solid var(--brown)',
   color: 'var(--gold)',
-  padding: '4px 6px',
+  padding: '5px 8px',
   cursor: 'pointer',
   outline: 'none',
 };
 
 const labelStyle: React.CSSProperties = {
-  fontSize: 5,
+  fontSize: 7,
   color: 'var(--gold-d)',
   letterSpacing: 1,
   fontFamily: 'var(--font-label)',
@@ -54,8 +54,8 @@ const LLMConfigBar: React.FC<LLMConfigBarProps> = ({ config, onConfigChange }) =
   return (
     <div style={{
       width: '100%',
-      maxWidth: 960,
-      padding: '0 16px 20px',
+      maxWidth: 1100,
+      padding: '0 8px 14px',
     }}>
       <div style={{
         background: 'var(--surface)',
@@ -114,7 +114,7 @@ const LLMConfigBar: React.FC<LLMConfigBarProps> = ({ config, onConfigChange }) =
             animation: isOnline ? 'status-dot-pulse 1.2s steps(1) infinite' : 'none',
           }} />
           <span style={{
-            fontSize: 5,
+            fontSize: 7,
             color: isOnline ? '#44cc66' : '#cc4444',
             fontFamily: 'var(--font-label)',
           }}>

--- a/frontend/src/components/player/BotSpeechBubble.tsx
+++ b/frontend/src/components/player/BotSpeechBubble.tsx
@@ -19,14 +19,14 @@ const BotSpeechBubble: React.FC<BotSpeechBubbleProps> = ({ text, side }) => {
       ...(isRight
         ? { left: 'calc(100% + 8px)', top: 0 }
         : { right: 'calc(100% + 8px)', top: 0 }),
-      width: 160,
+      width: 200,
       background: 'rgba(8, 7, 0, 0.96)',
       border: '1px solid var(--gold-d)',
       boxShadow: '0 0 8px rgba(200,160,64,0.15)',
       clipPath: 'var(--clip-sm)',
-      padding: '6px 10px',
+      padding: '8px 12px',
       fontFamily: 'var(--font-ai)',
-      fontSize: 18,
+      fontSize: 20,
       color: '#c8b080',
       lineHeight: 1.3,
       zIndex: 5,

--- a/frontend/src/components/player/HumanPanel.tsx
+++ b/frontend/src/components/player/HumanPanel.tsx
@@ -44,8 +44,8 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
       background: 'var(--surface)',
       border: '3px solid var(--gold-l)',
       boxShadow: '0 0 20px rgba(232,208,128,0.2), 3px 3px 0 #000',
-      padding: '12px 16px',
-      minWidth: 150,
+      padding: '14px 18px',
+      minWidth: 180,
       clipPath: 'var(--clip-md)',
       opacity: player.is_active ? 1 : 0.3,
       transition: 'opacity 0.3s ease',
@@ -53,10 +53,10 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
       {/* YOU tag */}
       <div style={{
         display: 'inline-block',
-        fontSize: 5,
+        fontSize: 7,
         background: 'var(--gold)',
         color: '#000',
-        padding: '2px 5px',
+        padding: '2px 6px',
         marginBottom: 6,
         fontFamily: 'var(--font-label)',
       }}>
@@ -66,7 +66,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
       {/* Player name */}
       <div style={{
         fontFamily: 'var(--font-ui)',
-        fontSize: 11,
+        fontSize: 14,
         color: 'var(--gold-l)',
         textShadow: '0 0 8px rgba(232,208,128,0.5)',
         marginBottom: 5,
@@ -77,7 +77,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
 
       {/* Chips */}
       <div style={{
-        fontSize: 8,
+        fontSize: 11,
         color: 'var(--gold)',
         marginBottom: 4,
         fontFamily: 'var(--font-label)',
@@ -87,7 +87,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
 
       {/* Position + status */}
       <div style={{
-        fontSize: 6,
+        fontSize: 8,
         color: ip ? '#66cc88' : 'var(--gold-d)',
         fontFamily: 'var(--font-label)',
         display: 'flex',
@@ -103,7 +103,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
       {player.current_bet > 0 && (
         <div style={{
           marginTop: 4,
-          fontSize: 5,
+          fontSize: 7,
           color: '#ffcc00',
           fontFamily: 'var(--font-label)',
         }}>

--- a/frontend/src/components/player/PlayerBox.tsx
+++ b/frontend/src/components/player/PlayerBox.tsx
@@ -33,8 +33,8 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   const boxStyle: React.CSSProperties = {
     background: 'rgba(10, 9, 0, 0.88)',
     border: '2px solid var(--brown)',
-    padding: '8px 10px',
-    width: 150,
+    padding: '10px 12px',
+    width: 180,
     position: 'relative',
     clipPath: 'var(--clip-sm)',
     opacity: isFolded ? 0.3 : 1,
@@ -54,11 +54,11 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   const bubbleEl = hasChipBubble ? (
     <div style={{
       fontFamily: 'var(--font-ui)',
-      fontSize: 5,
+      fontSize: 7,
       background: '#1a0e00',
       border: '1px solid var(--gold-d)',
       color: 'var(--gold)',
-      padding: '2px 6px',
+      padding: '3px 8px',
       alignSelf: 'center',
       flexShrink: 0,
       whiteSpace: 'nowrap',
@@ -80,12 +80,12 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         {badge && (
           <div style={{
             position: 'absolute',
-            top: -8,
+            top: -10,
             right: 5,
             background: 'var(--gold)',
             color: '#000',
-            fontSize: 4,
-            padding: '2px 5px',
+            fontSize: 6,
+            padding: '2px 6px',
             fontFamily: 'var(--font-ui)',
             lineHeight: 1.4,
           }}>
@@ -96,7 +96,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         {/* Bot name */}
         <div style={{
           fontFamily: 'var(--font-ui)',
-          fontSize: 7,
+          fontSize: 10,
           color: 'var(--gold)',
           marginBottom: 4,
           overflow: 'hidden',
@@ -108,7 +108,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
         {/* Chips */}
         <div style={{
-          fontSize: 5,
+          fontSize: 7,
           color: 'var(--gold-l)',
           marginBottom: 3,
           fontFamily: 'var(--font-label)',
@@ -118,7 +118,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
         {/* Status */}
         <div style={{
-          fontSize: 5,
+          fontSize: 7,
           color: status.color,
           fontFamily: 'var(--font-label)',
         }}>
@@ -126,7 +126,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         </div>
 
         {/* Cards (face-down or face-up at showdown) */}
-        <div style={{ display: 'flex', gap: 3, marginTop: 5 }}>
+        <div style={{ display: 'flex', gap: 4, marginTop: 6 }}>
           {showCards ? (
             <>
               <Card
@@ -142,12 +142,12 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
                 suit={(player.hand[1] as CardType).suit}
               />
             </>
-          ) : player.is_active ? (
+          ) : (
             <>
               <Card size="sm" variant="face-down" />
               <Card size="sm" variant="face-down" />
             </>
-          ) : null}
+          )}
         </div>
 
         {/* Speech bubble — floats outside this box via absolute positioning */}

--- a/frontend/src/components/table/CommunityCards.tsx
+++ b/frontend/src/components/table/CommunityCards.tsx
@@ -8,7 +8,7 @@ interface CommunityCardsProps {
 
 const CommunityCards: React.FC<CommunityCardsProps> = ({ cards }) => {
   return (
-    <div style={{ display: 'flex', gap: 8 }}>
+    <div style={{ display: 'flex', gap: 10 }}>
       {Array.from({ length: 5 }, (_, i) => {
         const card = cards[i];
         if (card) {

--- a/frontend/src/components/table/HoleCards.tsx
+++ b/frontend/src/components/table/HoleCards.tsx
@@ -11,7 +11,7 @@ const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn }) => {
   return (
     <div style={{
       position: 'absolute',
-      bottom: 20,
+      bottom: 24,
       left: '50%',
       transform: 'translateX(-50%)',
       display: 'flex',
@@ -21,7 +21,7 @@ const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn }) => {
     }}>
       {/* YOUR HAND label */}
       <div style={{
-        fontSize: 5,
+        fontSize: 7,
         color: 'var(--gold-d)',
         letterSpacing: 2,
         animation: 'blink 1s steps(1) infinite',
@@ -32,7 +32,7 @@ const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn }) => {
       </div>
 
       {/* Two hole cards */}
-      <div style={{ display: 'flex', gap: 10 }}>
+      <div style={{ display: 'flex', gap: 12 }}>
         {cards.slice(0, 2).map((card, i) =>
           card ? (
             <Card

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -48,10 +48,10 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
   return (
     <div style={{
       width: '100%',
-      maxWidth: 960,
-      padding: '20px 16px',
+      maxWidth: 1100,
+      padding: '12px 8px',
       display: 'grid',
-      gridTemplateColumns: '160px 1fr 160px',
+      gridTemplateColumns: '190px 1fr 190px',
       gridTemplateRows: 'auto',
     }}>
       {/* Felt wrap — spans all 3 columns */}
@@ -63,7 +63,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
         {/* The green felt */}
         <div style={{
           width: '100%',
-          minHeight: 480,
+          minHeight: 560,
           background: 'radial-gradient(ellipse 80% 70% at 50% 42%, var(--felt-c) 0%, #122012 55%, var(--felt-e) 100%)',
           border: '5px solid var(--gold)',
           boxShadow: '0 0 0 2px var(--gold-d), inset 0 0 60px rgba(0,0,0,0.45), 0 0 40px rgba(200,160,64,0.06)',
@@ -90,11 +90,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
           {/* Left bots (3) */}
           <div style={{
             position: 'absolute',
-            left: 16,
-            top: 24,
+            left: 10,
+            top: 20,
             display: 'flex',
             flexDirection: 'column',
-            gap: 10,
+            gap: 12,
           }}>
             {leftBots.map((bot, i) => {
               const playerIdx = i + 1; // bot 0→idx1, bot 1→idx2, bot 2→idx3
@@ -113,11 +113,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
           {/* Right bots (2) */}
           <div style={{
             position: 'absolute',
-            right: 16,
-            top: 24,
+            right: 10,
+            top: 20,
             display: 'flex',
             flexDirection: 'column',
-            gap: 10,
+            gap: 12,
             alignItems: 'flex-end',
           }}>
             {rightBots.map((bot, i) => {
@@ -139,11 +139,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
             position: 'absolute',
             top: '50%',
             left: '50%',
-            transform: 'translate(-50%, -58%)',
+            transform: 'translate(-50%, -55%)',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
-            gap: 10,
+            gap: 12,
           }}>
             <PotDisplay pot={pot} street={state} />
             <CommunityCards cards={community_cards} />
@@ -165,8 +165,8 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
           {humanPlayer && (
             <div style={{
               position: 'absolute',
-              bottom: 16,
-              right: 16,
+              bottom: 20,
+              right: 10,
             }}>
               <HumanPanel
                 player={humanPlayer}
@@ -190,19 +190,19 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
                 transform: 'translateX(-50%)',
                 background: 'rgba(0,0,0,0.88)',
                 border: '3px solid var(--gold)',
-                padding: '12px 24px',
+                padding: '14px 28px',
                 textAlign: 'center',
                 clipPath: 'var(--clip-md)',
                 zIndex: 10,
                 whiteSpace: 'nowrap',
               }}>
-                <div style={{ fontSize: 5, color: 'var(--gold-d)', letterSpacing: 3, marginBottom: 8, fontFamily: 'var(--font-label)' }}>
+                <div style={{ fontSize: 7, color: 'var(--gold-d)', letterSpacing: 3, marginBottom: 8, fontFamily: 'var(--font-label)' }}>
                   ◈ SHOWDOWN ◈
                 </div>
-                <div style={{ fontSize: 9, color: 'var(--gold)', letterSpacing: 1, marginBottom: 6, fontFamily: 'var(--font-ui)' }}>
+                <div style={{ fontSize: 12, color: 'var(--gold)', letterSpacing: 1, marginBottom: 6, fontFamily: 'var(--font-ui)' }}>
                   {winnerNames}
                 </div>
-                <div style={{ fontSize: 6, color: 'var(--gold-l)', fontFamily: 'var(--font-label)', letterSpacing: 1 }}>
+                <div style={{ fontSize: 8, color: 'var(--gold-l)', fontFamily: 'var(--font-label)', letterSpacing: 1 }}>
                   {gameState.winning_hand}
                 </div>
               </div>

--- a/frontend/src/components/table/PotDisplay.tsx
+++ b/frontend/src/components/table/PotDisplay.tsx
@@ -10,7 +10,7 @@ const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
     <div style={{ textAlign: 'center' }}>
       {/* Street label */}
       <div style={{
-        fontSize: 5,
+        fontSize: 7,
         color: 'var(--gold-d)',
         letterSpacing: 3,
         marginBottom: 4,
@@ -20,7 +20,7 @@ const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
       </div>
       {/* Pot amount */}
       <div style={{
-        fontSize: 7,
+        fontSize: 10,
         color: 'var(--gold-l)',
         letterSpacing: 2,
         textShadow: '0 0 6px var(--gold)',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,9 +36,9 @@
   --font-label: 'Press Start 2P', monospace;
 
   /* === Shadows === */
-  --shadow-card-lg: 3px 3px 0 #000;
+  --shadow-card-lg: 4px 4px 0 #000;
   --shadow-card-md: 3px 3px 0 #000;
-  --shadow-card-sm: 1px 1px 0 #000;
+  --shadow-card-sm: 2px 2px 0 #000;
   --shadow-card-xs: 1px 1px 0 #000;
 
   /* === Glows === */
@@ -47,7 +47,7 @@
   --glow-green: 0 0 10px rgba(102, 204, 136, 0.4);
 
   /* === Clip-Paths === */
-  --clip-lg: polygon(5px 0%, calc(100% - 5px) 0%, 100% 5px, 100% calc(100% - 5px), calc(100% - 5px) 100%, 5px 100%, 0% calc(100% - 5px), 0% 5px);
+  --clip-lg: polygon(6px 0%, calc(100% - 6px) 0%, 100% 6px, 100% calc(100% - 6px), calc(100% - 6px) 100%, 6px 100%, 0% calc(100% - 6px), 0% 6px);
   --clip-md: polygon(5px 0%, calc(100% - 5px) 0%, 100% 5px, 100% calc(100% - 5px), calc(100% - 5px) 100%, 5px 100%, 0% calc(100% - 5px), 0% 5px);
   --clip-sm: polygon(4px 0%, calc(100% - 4px) 0%, 100% 4px, 100% calc(100% - 4px), calc(100% - 4px) 100%, 4px 100%, 0% calc(100% - 4px), 0% 4px);
   --clip-xs: polygon(3px 0%, calc(100% - 3px) 0%, 100% 3px, 100% calc(100% - 3px), calc(100% - 3px) 100%, 3px 100%, 0% calc(100% - 3px), 0% 3px);
@@ -116,8 +116,8 @@
 @layer components {
   .abtn {
     font-family: var(--font-ui);
-    font-size: 8px;
-    padding: 11px 16px;
+    font-size: 11px;
+    padding: 13px 20px;
     border: 3px solid;
     cursor: pointer;
     background: var(--surface);
@@ -171,12 +171,12 @@
 
   .raise-inp {
     font-family: var(--font-label);
-    font-size: 7px;
+    font-size: 10px;
     background: #000;
     border: 2px solid var(--brown);
     color: var(--gold-l);
-    padding: 11px 10px;
-    width: 80px;
+    padding: 13px 12px;
+    width: 110px;
     outline: none;
   }
   .raise-inp:focus {


### PR DESCRIPTION
Adopt card_v3.html dimensions and scale all fonts ~1.4x to improve readability. Reduce page margins to maximise table space.

Card sizes (card_v3.html spec):
- LG 62×88 → 74×104  (community cards, +19%)
- MD 58×82 → 62×88   (human hole cards, old LG dims)
- SM 30×42 → 38×54   (bot cards, +40%)

Font sizes (representative):
- Bot name 7→10, chips/status 5→7, badge 4→6
- Pot label 5→7, pot amount 7→10
- Action buttons 8→11px; raise input 7→10px, 80→110px wide
- HumanPanel name 11→14, chips 8→11
- Header logo 18→20, HUD stats 6→8
- AI Coach title 7→10, recommendation 12→15, stat values 10→13

Layout:
- Table max-width 960→1100, padding 20px 16px → 12px 8px
- Grid columns 160px → 190px; felt min-height 480→560
- Bot column insets 16→10px, gap 10→12px
- ActionBar/LLMConfigBar max-width and padding reduced to match

UX fix:
- Folded bots now show face-down cards (dimmed at 0.3 opacity) instead of rendering nothing

TypeScript: 0 errors. Backend: 50/50 tests pass.