### PR TITLE
feat: add pseudo-GTO bot strategy + GTO coach system

### DIFF
--- a/backend/src/ai/board_texture.py
+++ b/backend/src/ai/board_texture.py
@@ -1,0 +1,108 @@
+"""
+Board texture analyzer for Texas Hold'em community cards.
+
+Classifies the board as dry / semi-wet / wet and detects draws.
+Used by GTO strategy and GTO coach to select appropriate bet sizing.
+"""
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from typing import List
+
+from ..engine import Card
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BoardTexture:
+    """Describes the strategic texture of the community cards."""
+    wetness: float        # 0.0 (dry) → 1.0 (very wet)
+    flush_draw: bool      # True if 3+ cards of same suit
+    straight_draw: bool   # True if 3+ connected cards (including gutshots)
+    paired: bool          # True if board contains a pair
+    high_card: int        # Highest community card rank value (or 0 if no board)
+
+
+def analyze_board(community: List[Card]) -> BoardTexture:
+    """
+    Analyze community cards and return a BoardTexture.
+
+    Works for any board size (0–5 cards); an empty board returns
+    a neutral texture.
+    """
+    if not community:
+        return BoardTexture(
+            wetness=0.3,
+            flush_draw=False,
+            straight_draw=False,
+            paired=False,
+            high_card=0,
+        )
+
+    ranks = sorted([c.rank.value for c in community], reverse=True)
+    suits = [c.suit for c in community]
+
+    high_card = ranks[0] if ranks else 0
+
+    # ── Flush draw (3+ same suit) ─────────────────────────────────────────────
+    suit_counts = Counter(suits)
+    flush_draw = max(suit_counts.values()) >= 3
+
+    # ── Paired board ─────────────────────────────────────────────────────────
+    rank_counts = Counter(ranks)
+    paired = max(rank_counts.values()) >= 2
+
+    # ── Straight draw (3+ connected within a 5-card window) ──────────────────
+    unique_ranks = sorted(set(ranks))
+    # Check for any 3 ranks within a span of 4 (open-ended or gutshot)
+    straight_draw = _has_straight_draw(unique_ranks)
+
+    # ── Wetness formula ───────────────────────────────────────────────────────
+    wetness = (
+        0.4 * float(flush_draw)
+        + 0.4 * float(straight_draw)
+        + 0.2 * float(paired)
+    )
+    # Clamp to [0, 1]
+    wetness = max(0.0, min(1.0, wetness))
+
+    return BoardTexture(
+        wetness=wetness,
+        flush_draw=flush_draw,
+        straight_draw=straight_draw,
+        paired=paired,
+        high_card=high_card,
+    )
+
+
+def _has_straight_draw(unique_ranks: List[int]) -> bool:
+    """
+    Return True if there are at least 3 cards within any 5-card rank window.
+
+    This catches open-ended straight draws (OESD) and gutshots.
+    Also handles the Ace-low wheel draw (A-2-3-4-5).
+    """
+    if len(unique_ranks) < 3:
+        return False
+
+    # Add Ace as 1 for wheel draw detection
+    extended = list(unique_ranks)
+    if 14 in extended:
+        extended.append(1)
+    extended = sorted(set(extended))
+
+    # Slide a 5-rank window and count unique ranks inside.
+    # The window can start as low as (min - 4) to cover boards like J-Q-K
+    # where the 9-K or T-A window catches the draw.
+    lo_start = max(1, min(extended) - 4)
+    hi_end = max(extended) + 1
+    for low in range(lo_start, hi_end):
+        high = low + 4  # window spans 5 ranks: low..low+4
+        count = sum(1 for r in extended if low <= r <= high)
+        if count >= 3:
+            return True
+
+    return False

--- a/backend/src/ai/equity.py
+++ b/backend/src/ai/equity.py
@@ -1,0 +1,120 @@
+"""
+Monte Carlo equity estimator for Texas Hold'em.
+
+Estimates win probability via random simulation — no external poker library
+required. Uses the project's existing HandEvaluator.
+"""
+from __future__ import annotations
+
+import logging
+import random
+from typing import List
+
+from ..engine import Card, HandEvaluator
+from ..schemas import Rank, Suit
+
+logger = logging.getLogger(__name__)
+
+# ─── Full deck helper ─────────────────────────────────────────────────────────
+
+def _build_full_deck() -> List[Card]:
+    """Return a list of all 52 cards."""
+    return [Card(rank=r, suit=s) for r in Rank for s in Suit]
+
+
+def _card_key(card: Card) -> tuple[int, str]:
+    return (card.rank.value, card.suit.value)
+
+
+# ─── Main estimator ───────────────────────────────────────────────────────────
+
+def estimate_equity(
+    my_hand: List[Card],
+    community: List[Card],
+    num_opponents: int,
+    n_sim: int = 400,
+) -> float:
+    """
+    Estimate win equity via Monte Carlo simulation.
+
+    Parameters
+    ----------
+    my_hand : list[Card]
+        The 2 hole cards of the evaluating player.
+    community : list[Card]
+        Currently visible community cards (0–5).
+    num_opponents : int
+        Number of active opponents still in the hand.
+    n_sim : int
+        Number of simulations. 400 ≈ 3–6ms on typical hardware.
+
+    Returns
+    -------
+    float
+        Estimated equity in [0.0, 1.0].
+        Formula: (wins + 0.5 * ties) / n_sim
+    """
+    if not my_hand or num_opponents <= 0:
+        return 0.5
+
+    num_opponents = max(1, min(num_opponents, 5))
+    cards_needed = 5 - len(community)  # community cards still to come
+
+    # Build the remaining deck (exclude known cards)
+    known_keys = {_card_key(c) for c in my_hand + community}
+    remaining = [c for c in _build_full_deck() if _card_key(c) not in known_keys]
+
+    wins = 0
+    ties = 0
+
+    for _ in range(n_sim):
+        try:
+            # Sample enough cards for opponents + remaining board
+            cards_needed_total = num_opponents * 2 + cards_needed
+            if cards_needed_total > len(remaining):
+                # Edge case: not enough cards (should never happen in valid state)
+                break
+
+            sampled = random.sample(remaining, cards_needed_total)
+
+            # Distribute: first (num_opponents * 2) cards go to opponents
+            opp_hands: List[List[Card]] = []
+            for i in range(num_opponents):
+                opp_hands.append([sampled[i * 2], sampled[i * 2 + 1]])
+
+            # Remaining cards complete the board
+            board = list(community) + sampled[num_opponents * 2:]
+
+            # Evaluate all hands (need exactly 5-card board)
+            my_rank, my_tb = HandEvaluator.evaluate(my_hand + board)
+
+            best_opp_rank = None
+            best_opp_tb: List[int] = []
+            for opp_hand in opp_hands:
+                opp_rank, opp_tb = HandEvaluator.evaluate(opp_hand + board)
+                if best_opp_rank is None or opp_rank.value > best_opp_rank.value:
+                    best_opp_rank = opp_rank
+                    best_opp_tb = opp_tb
+                elif opp_rank.value == best_opp_rank.value and opp_tb > best_opp_tb:
+                    best_opp_tb = opp_tb
+
+            if best_opp_rank is None:
+                wins += 1
+                continue
+
+            if my_rank.value > best_opp_rank.value:
+                wins += 1
+            elif my_rank.value == best_opp_rank.value:
+                if my_tb > best_opp_tb:
+                    wins += 1
+                elif my_tb == best_opp_tb:
+                    ties += 1
+                # else: loss
+        except Exception as exc:
+            logger.debug('equity sim error: %s', exc)
+            continue
+
+    total = n_sim
+    if total == 0:
+        return 0.5
+    return (wins + 0.5 * ties) / total

--- a/backend/src/ai/gto_coach.py
+++ b/backend/src/ai/gto_coach.py
@@ -1,0 +1,400 @@
+"""
+GTO Coach for the human player — no LLM required.
+
+Provides position-based pre-flop analysis and Monte Carlo equity-based
+post-flop advice. Returns the same dict schema as AICoach so the frontend
+needs no changes.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional
+
+from ..engine import Card, Rank, Suit
+from .preflop_ranges import (
+    get_hand_combo,
+    get_position,
+    preflop_open_freq,
+    preflop_call_freq,
+)
+from .equity import estimate_equity
+from .board_texture import analyze_board
+
+logger = logging.getLogger(__name__)
+
+# ─── Card parsing (same helper as in gto_strategy) ───────────────────────────
+
+def _dict_to_card(d: Optional[dict[str, Any]]) -> Optional[Card]:
+    if d is None:
+        return None
+    try:
+        rank = Rank(int(d['rank']))
+        suit = Suit(str(d['suit']))
+        return Card(rank=rank, suit=suit)
+    except (KeyError, ValueError):
+        return None
+
+
+def _parse_hand(hand_raw: List[Optional[dict[str, Any]]]) -> List[Card]:
+    result: List[Card] = []
+    for d in hand_raw:
+        card = _dict_to_card(d)
+        if card is not None:
+            result.append(card)
+    return result
+
+
+# ─── Rank / suit display helpers ─────────────────────────────────────────────
+
+_RANK_CHAR = {
+    14: 'A', 13: 'K', 12: 'Q', 11: 'J', 10: 'T',
+    9: '9', 8: '8', 7: '7', 6: '6', 5: '5', 4: '4', 3: '3', 2: '2',
+}
+_SUIT_CHAR = {
+    'Hearts': '♥', 'Diamonds': '♦', 'Clubs': '♣', 'Spades': '♠',
+}
+
+
+def _card_str(card: Card) -> str:
+    r = _RANK_CHAR.get(card.rank.value, str(card.rank.value))
+    s = _SUIT_CHAR.get(card.suit.value, card.suit.value[0])
+    return r + s
+
+
+def _quality(value: float, good_threshold: float, bad_threshold: float) -> str:
+    """Map a numeric value to a quality label."""
+    if value >= good_threshold:
+        return 'good'
+    if value <= bad_threshold:
+        return 'bad'
+    return 'neutral'
+
+
+# ─── GTO Coach ────────────────────────────────────────────────────────────────
+
+class GTOCoach:
+    """
+    GTO-based coaching analysis — works without any LLM.
+
+    Interface is identical to AICoach.analyze() so main.py needs no changes:
+        async def analyze(game_state, player_id) -> dict[str, Any]
+    """
+
+    # Number of simulations for equity estimation
+    N_SIM: int = 500
+
+    async def analyze(self, game_state: dict[str, Any], player_id: str) -> dict[str, Any]:
+        """
+        Analyze the current game state for the human player.
+
+        Returns a dict matching the AICoachAdvice TypeScript interface:
+            { recommendation, recommendedAmount, body, stats }
+        """
+        try:
+            return self._analyze_sync(game_state, player_id)
+        except Exception as exc:
+            logger.error('GTOCoach.analyze error: %s', exc)
+            return self._fallback()
+
+    def _analyze_sync(self, game_state: dict[str, Any], player_id: str) -> dict[str, Any]:
+        players: List[dict[str, Any]] = game_state.get('players', [])
+        me = next((p for p in players if p['id'] == player_id), None)
+        if me is None:
+            return self._fallback()
+
+        street: str = game_state.get('state', 'PREFLOP')
+        pot: int = game_state.get('pot', 0)
+        current_bet: int = game_state.get('current_bet', 0)
+        min_raise: int = game_state.get('min_raise', 20)
+        my_bet: int = me.get('current_bet', 0)
+        my_chips: int = me.get('chips', 0)
+        to_call: int = max(0, current_bet - my_bet)
+        can_check: bool = to_call == 0
+
+        my_hand = _parse_hand(me.get('hand', []))
+        community_raw: List[Any] = game_state.get('community_cards', [])
+        community = _parse_hand(community_raw)
+
+        opponents = [p for p in players if p['id'] != player_id]
+        active_opponents = sum(1 for p in opponents if p.get('is_active'))
+
+        # Position
+        dealer_idx = next(
+            (i for i, p in enumerate(players) if p.get('is_dealer')), 0
+        )
+        my_idx = next((i for i, p in enumerate(players) if p['id'] == player_id), 0)
+        position = get_position(my_idx, dealer_idx, len(players))
+        position_label = _position_display(position)
+
+        hand_str = ' '.join(_card_str(c) for c in my_hand) if my_hand else '??'
+        board_str = ' '.join(_card_str(c) for c in community) if community else '（等待翻牌）'
+
+        if street == 'PREFLOP':
+            return self._analyze_preflop(
+                my_hand=my_hand,
+                hand_str=hand_str,
+                position=position,
+                position_label=position_label,
+                to_call=to_call,
+                can_check=can_check,
+                pot=pot,
+                min_raise=min_raise,
+                my_chips=my_chips,
+                active_opponents=active_opponents,
+            )
+        else:
+            return self._analyze_postflop(
+                my_hand=my_hand,
+                hand_str=hand_str,
+                community=community,
+                board_str=board_str,
+                street=street,
+                position=position,
+                position_label=position_label,
+                to_call=to_call,
+                can_check=can_check,
+                pot=pot,
+                min_raise=min_raise,
+                my_chips=my_chips,
+                active_opponents=active_opponents,
+            )
+
+    # ── Pre-flop analysis ─────────────────────────────────────────────────────
+
+    def _analyze_preflop(
+        self,
+        my_hand: List[Card],
+        hand_str: str,
+        position: str,
+        position_label: str,
+        to_call: int,
+        can_check: bool,
+        pot: int,
+        min_raise: int,
+        my_chips: int,
+        active_opponents: int,
+    ) -> dict[str, Any]:
+        if len(my_hand) < 2:
+            return self._fallback()
+
+        combo = get_hand_combo(my_hand[0], my_hand[1])
+        open_f = preflop_open_freq(combo, position)
+        call_f = preflop_call_freq(combo, position)
+
+        if can_check:
+            freq = open_f
+            if freq >= 0.8:
+                rec = 'RAISE'
+                rec_amount = min(int(min_raise * 2.5), my_chips)
+                strength_label = '强'
+                action_desc = f'这是一手在 {position_label} 的强起手牌（开注频率 {freq:.0%}），标准开注尺度为 2.5×BB。'
+            elif freq >= 0.5:
+                rec = 'RAISE'
+                rec_amount = min(int(min_raise * 2.5), my_chips)
+                strength_label = '中等偏强'
+                action_desc = f'在 {position_label} 此手牌属于中等偏强范围（开注频率 {freq:.0%}），可以开注。'
+            elif freq >= 0.2:
+                rec = 'CHECK'
+                rec_amount = None
+                strength_label = '边缘'
+                action_desc = f'在 {position_label} 此手牌属于边缘范围（开注频率 {freq:.0%}），可以用混频策略开注或 check。'
+            else:
+                rec = 'FOLD'
+                rec_amount = None
+                strength_label = '弱'
+                action_desc = f'在 {position_label} 此手牌范围外（GTO 开注频率 {freq:.0%}），建议弃牌。'
+        else:
+            # Facing a raise
+            freq = call_f
+            pot_odds = to_call / (pot + to_call + 1e-6)
+            if freq >= 0.75:
+                rec = 'CALL'
+                rec_amount = None
+                strength_label = '强'
+                action_desc = f'面对加注，{combo} 在 {position_label} 的跟注频率为 {freq:.0%}，满足底池赔率要求（{pot_odds:.0%}），建议跟注。'
+            elif freq >= 0.4:
+                rec = 'CALL'
+                rec_amount = None
+                strength_label = '可跟注'
+                action_desc = f'面对加注，{combo} 在 {position_label} 跟注频率 {freq:.0%}，属于混频跟注范围。'
+            else:
+                rec = 'FOLD'
+                rec_amount = None
+                strength_label = '范围外'
+                action_desc = f'面对加注，{combo} 在 {position_label} 超出跟注范围（频率 {freq:.0%}），建议弃牌。'
+
+        # Stats
+        rec_quality = 'hot' if rec == 'RAISE' else ('good' if rec == 'CALL' else 'bad')
+        pos_quality = _pos_quality(position)
+
+        body = (
+            f'【翻牌前分析】手牌：{hand_str}，位置：{position_label}\n\n'
+            f'{action_desc}\n\n'
+            f'GTO 要点：\n'
+            f'• 开注范围：{position_label} GTO 开注约 {_approx_open_pct(position)}% 的手牌\n'
+            f'• {combo} 属于{strength_label}手牌，开注频率 {open_f:.0%}\n'
+            f'• 翻牌前混频策略避免对手锁定你的范围\n'
+            f'• 注意位置优势：BTN > CO > MP > EP'
+        )
+
+        stats = [
+            {'label': '手牌强度', 'value': strength_label, 'quality': _quality(open_f, 0.7, 0.3)},
+            {'label': '开注频率', 'value': f'{open_f:.0%}', 'quality': _quality(open_f, 0.6, 0.25)},
+            {'label': '位置', 'value': position_label, 'quality': pos_quality},
+            {'label': '推荐', 'value': rec, 'quality': rec_quality},
+        ]
+
+        return {
+            'recommendation': rec,
+            'recommendedAmount': rec_amount,
+            'body': body,
+            'stats': stats,
+        }
+
+    # ── Post-flop analysis ────────────────────────────────────────────────────
+
+    def _analyze_postflop(
+        self,
+        my_hand: List[Card],
+        hand_str: str,
+        community: List[Card],
+        board_str: str,
+        street: str,
+        position: str,
+        position_label: str,
+        to_call: int,
+        can_check: bool,
+        pot: int,
+        min_raise: int,
+        my_chips: int,
+        active_opponents: int,
+    ) -> dict[str, Any]:
+        num_opp = max(1, active_opponents)
+        equity = estimate_equity(my_hand, community, num_opp, n_sim=self.N_SIM)
+        texture = analyze_board(community)
+
+        pot_odds = to_call / (pot + to_call + 1e-6) if to_call > 0 else 0.0
+
+        # Bet size for recommendation
+        if texture.wetness >= 0.5:
+            bet_fraction = 0.66
+            value_threshold = 0.70
+        else:
+            bet_fraction = 0.33
+            value_threshold = 0.65
+        bet_size = max(int(pot * bet_fraction), min_raise)
+        bet_size = min(bet_size, my_chips)
+
+        bluff_freq = bet_size / (pot + 2 * bet_size + 1e-6)
+
+        # Recommendation
+        if can_check:
+            if equity >= value_threshold:
+                rec = 'RAISE'
+                rec_amount = bet_size
+                rec_reason = f'胜率 {equity:.0%} 超过价值下注阈值（{value_threshold:.0%}），建议下注 {int(bet_fraction * 100)}% 底池获取价值。'
+            elif equity >= 0.45:
+                rec = 'CHECK'
+                rec_amount = None
+                rec_reason = f'胜率 {equity:.0%} 属中等，建议 check 进行底池控制，避免膨胀底池。'
+            else:
+                rec = 'CHECK'
+                rec_amount = None
+                rec_reason = f'胜率 {equity:.0%} 较低，建议 check。如果对手下注可以考虑弃牌（GTO 诈唬频率 {bluff_freq:.0%}）。'
+        else:
+            if equity > pot_odds + 0.12:
+                rec = 'CALL'
+                rec_amount = None
+                rec_reason = f'胜率 {equity:.0%} 远超底池赔率 {pot_odds:.0%}，建议跟注，有充分的权益优势。'
+            elif equity > pot_odds + 0.05:
+                rec = 'CALL'
+                rec_amount = None
+                rec_reason = f'胜率 {equity:.0%} 略高于底池赔率 {pot_odds:.0%}，属于临界跟注，建议跟注。'
+            else:
+                rec = 'FOLD'
+                rec_amount = None
+                rec_reason = f'胜率 {equity:.0%} 不满足底池赔率要求 {pot_odds:.0%}，建议弃牌。'
+
+        # Board texture description
+        texture_parts = []
+        if texture.flush_draw:
+            texture_parts.append('同花听牌')
+        if texture.straight_draw:
+            texture_parts.append('顺子听牌')
+        if texture.paired:
+            texture_parts.append('对子牌面')
+        texture_desc = '、'.join(texture_parts) if texture_parts else '干燥牌面'
+        wetness_label = '湿润' if texture.wetness >= 0.5 else '干燥'
+
+        street_cn = {'FLOP': '翻牌', 'TURN': '转牌', 'RIVER': '河牌'}.get(street, street)
+
+        body = (
+            f'【{street_cn}分析】手牌：{hand_str}，公共牌：{board_str}\n\n'
+            f'{rec_reason}\n\n'
+            f'GTO 要点：\n'
+            f'• 胜率：{equity:.0%}，底池赔率：{pot_odds:.0%}（需要满足才能盈利跟注）\n'
+            f'• 牌面质地：{texture_desc}（{wetness_label}，湿润度 {texture.wetness:.0%}）\n'
+            f'• 建议下注尺度：{int(bet_fraction * 100)}% 底池（约 ${bet_size}）\n'
+            f'• GTO 诈唬比例：{bluff_freq:.0%}，保持价值/诈唬平衡\n'
+            f'• 位置：{position_label}，{"有位置优势" if _is_ip(position) else "位置劣势，注意保守"}'
+        )
+
+        rec_quality = 'hot' if rec == 'RAISE' else ('good' if rec == 'CALL' else 'bad')
+        pos_quality = _pos_quality(position)
+        odds_quality = _quality(equity - pot_odds, 0.1, -0.05)
+
+        stats = [
+            {'label': '胜率估计', 'value': f'{equity:.0%}', 'quality': _quality(equity, 0.65, 0.40)},
+            {'label': '底池赔率', 'value': f'{pot_odds:.0%}', 'quality': odds_quality},
+            {'label': '位置', 'value': position_label + (' ✓' if _is_ip(position) else ' ✗'), 'quality': pos_quality},
+            {'label': '推荐', 'value': rec, 'quality': rec_quality},
+        ]
+
+        return {
+            'recommendation': rec,
+            'recommendedAmount': rec_amount,
+            'body': body,
+            'stats': stats,
+        }
+
+    def _fallback(self) -> dict[str, Any]:
+        return {
+            'recommendation': 'CHECK',
+            'recommendedAmount': None,
+            'body': 'GTO Coach 暂时无法分析当前局面，请稍后再试。',
+            'stats': [
+                {'label': '状态', 'value': 'ERROR', 'quality': 'bad'},
+            ],
+        }
+
+
+# ─── Position helpers ─────────────────────────────────────────────────────────
+
+def _position_display(pos: str) -> str:
+    mapping = {
+        'BTN': 'BTN（按钮位）',
+        'CO': 'CO（截止位）',
+        'MP': 'MP（中间位）',
+        'EP': 'EP（早期位）',
+        'SB': 'SB（小盲）',
+        'BB': 'BB（大盲）',
+    }
+    return mapping.get(pos, pos)
+
+
+def _is_ip(pos: str) -> bool:
+    """Return True if the position has positional advantage (acts last post-flop)."""
+    return pos in ('BTN', 'CO')
+
+
+def _pos_quality(pos: str) -> str:
+    if pos in ('BTN', 'CO'):
+        return 'good'
+    if pos in ('SB', 'EP'):
+        return 'bad'
+    return 'neutral'
+
+
+def _approx_open_pct(pos: str) -> int:
+    """Approximate open-raise percentage for position label."""
+    return {'BTN': 65, 'CO': 50, 'MP': 35, 'EP': 22, 'SB': 45, 'BB': 0}.get(pos, 35)

--- a/backend/src/ai/gto_strategy.py
+++ b/backend/src/ai/gto_strategy.py
@@ -1,0 +1,354 @@
+"""
+Pseudo-GTO bot strategy for Texas Hold'em.
+
+Pre-flop  : position-based range tables with mixed-frequency decisions.
+Post-flop : Monte Carlo equity + board texture → geometric bet sizing + GTO bluff freq.
+
+No external poker library required.
+"""
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, List, Optional
+
+from ..engine import Card, Rank, Suit
+from ..schemas import AIThought
+from .strategy import BotStrategy
+from .preflop_ranges import get_hand_combo, get_position, preflop_open_freq, preflop_call_freq
+from .equity import estimate_equity
+from .board_texture import analyze_board, BoardTexture
+
+logger = logging.getLogger(__name__)
+
+# ─── Chat message pools ───────────────────────────────────────────────────────
+
+_CHAT: dict[str, List[str]] = {
+    'fold':  [
+        'Not my spot.', 'I fold.', 'Bad equity.', 'Range disadvantage.',
+        'Folding this one.', 'Not profitable here.',
+    ],
+    'check': [
+        'Checking.', 'I check.', 'Pot control.', 'Taking a free card.',
+        'Check.', 'Checking my option.',
+    ],
+    'call':  [
+        'Call.', 'I call.', "I've got the odds.", 'Calling.',
+        'Price is right.', 'Pot odds check out.',
+    ],
+    'raise': [
+        'Raise.', 'I raise.', "I'm ahead here.", 'Value bet.',
+        'Geometric sizing.', 'Building the pot.', 'Let\'s play.',
+    ],
+}
+
+
+def _chat(action: str) -> str:
+    return random.choice(_CHAT.get(action, ['...']))
+
+
+# ─── Card reconstruction from game-state dicts ───────────────────────────────
+
+def _dict_to_card(d: Optional[dict[str, Any]]) -> Optional[Card]:
+    """Convert a card dict {'rank': int, 'suit': str} to a Card object."""
+    if d is None:
+        return None
+    try:
+        rank = Rank(int(d['rank']))
+        suit = Suit(str(d['suit']))
+        return Card(rank=rank, suit=suit)
+    except (KeyError, ValueError) as exc:
+        logger.debug('_dict_to_card failed: %s — %s', d, exc)
+        return None
+
+
+def _parse_hand(hand_raw: List[Optional[dict[str, Any]]]) -> List[Card]:
+    """Parse a list of card dicts (may contain None) into Card objects."""
+    result: List[Card] = []
+    for d in hand_raw:
+        card = _dict_to_card(d)
+        if card is not None:
+            result.append(card)
+    return result
+
+
+# ─── Strategy ─────────────────────────────────────────────────────────────────
+
+class GTOBotStrategy(BotStrategy):
+    """
+    Pseudo-GTO bot strategy.
+
+    Pre-flop decisions use position-based RFI and call frequency tables.
+    Post-flop decisions use Monte Carlo equity, board texture analysis,
+    and GTO-balanced bet sizing / bluff frequencies.
+    """
+
+    # Number of Monte Carlo simulations per decision
+    N_SIM_POSTFLOP: int = 300
+
+    def decide(self, game_state: dict[str, Any], player_id: str) -> AIThought:
+        """Main entry: dispatch to pre- or post-flop logic."""
+        street: str = game_state.get('state', 'PREFLOP')
+        players: List[dict[str, Any]] = game_state.get('players', [])
+
+        me = next((p for p in players if p['id'] == player_id), None)
+        if me is None:
+            logger.warning('GTOBotStrategy: player %s not found in state', player_id)
+            return AIThought(action='fold', amount=0, thought='player not found', chat_message='Fold.')
+
+        my_hand = _parse_hand(me.get('hand', []))
+        if not my_hand:
+            # No visible hand (shouldn't happen for the bot itself)
+            return AIThought(action='fold', amount=0, thought='no hand', chat_message='Fold.')
+
+        community_raw: List[dict[str, Any]] = game_state.get('community_cards', [])
+        community = _parse_hand(community_raw)
+
+        active_players = [p for p in players if p.get('is_active') and not p.get('is_all_in')]
+        active_opponents = max(0, len(active_players) - 1)
+
+        pot: int = game_state.get('pot', 0)
+        current_bet: int = game_state.get('current_bet', 0)
+        min_raise: int = game_state.get('min_raise', 20)
+        my_bet: int = me.get('current_bet', 0)
+        my_chips: int = me.get('chips', 0)
+        to_call: int = max(0, current_bet - my_bet)
+        can_check: bool = to_call == 0
+
+        # Find dealer index
+        dealer_idx = next(
+            (i for i, p in enumerate(players) if p.get('is_dealer')), 0
+        )
+        my_idx = next((i for i, p in enumerate(players) if p['id'] == player_id), 0)
+        position = get_position(my_idx, dealer_idx, len(players))
+
+        if street == 'PREFLOP':
+            return self._decide_preflop(
+                my_hand=my_hand,
+                position=position,
+                to_call=to_call,
+                can_check=can_check,
+                pot=pot,
+                min_raise=min_raise,
+                my_chips=my_chips,
+            )
+        else:
+            return self._decide_postflop(
+                my_hand=my_hand,
+                community=community,
+                active_opponents=active_opponents,
+                to_call=to_call,
+                can_check=can_check,
+                pot=pot,
+                min_raise=min_raise,
+                my_chips=my_chips,
+            )
+
+    # ── Pre-flop ──────────────────────────────────────────────────────────────
+
+    def _decide_preflop(
+        self,
+        my_hand: List[Card],
+        position: str,
+        to_call: int,
+        can_check: bool,
+        pot: int,
+        min_raise: int,
+        my_chips: int,
+    ) -> AIThought:
+        combo = get_hand_combo(my_hand[0], my_hand[1])
+        open_f = preflop_open_freq(combo, position)
+        call_f = preflop_call_freq(combo, position)
+
+        # BB special case: no open-raise needed (already posted)
+        if position == 'BB' and can_check:
+            # BB can squeeze with 3-bet hands or check
+            if open_f > 0.7 and random.random() < 0.4:
+                raise_amount = min(min_raise * 3, my_chips)
+                if raise_amount > 0:
+                    return AIThought(
+                        action='raise', amount=raise_amount,
+                        thought=f'BB squeeze: {combo} ({open_f:.0%} freq)',
+                        chat_message=_chat('raise'),
+                    )
+            return AIThought(
+                action='check', amount=0,
+                thought=f'BB check: {combo}',
+                chat_message=_chat('check'),
+            )
+
+        if can_check:
+            # Nobody has raised — decide whether to open-raise
+            if open_f > 0 and random.random() < open_f:
+                # Standard open: 2.5× BB (big_blind ≈ min_raise here)
+                raise_amount = min(min_raise * 2 + (min_raise // 2), my_chips)
+                raise_amount = max(raise_amount, min_raise)
+                return AIThought(
+                    action='raise', amount=raise_amount,
+                    thought=f'Open raise: {combo} at {position} ({open_f:.0%})',
+                    chat_message=_chat('raise'),
+                )
+            return AIThought(
+                action='check', amount=0,
+                thought=f'Check behind: {combo} at {position}',
+                chat_message=_chat('check'),
+            )
+        else:
+            # There is a raise to face
+            if to_call >= my_chips:
+                # All-in or fold decision
+                if call_f > 0 and random.random() < call_f * 0.5:
+                    return AIThought(
+                        action='call', amount=0,
+                        thought=f'All-in call: {combo}',
+                        chat_message=_chat('call'),
+                    )
+                return AIThought(
+                    action='fold', amount=0,
+                    thought=f'Fold to all-in: {combo}',
+                    chat_message=_chat('fold'),
+                )
+
+            # 3-bet opportunity: strong hands get aggressive
+            three_bet_f = max(0.0, open_f - 0.5)  # only widest openers 3-bet
+            if three_bet_f > 0 and random.random() < three_bet_f * 0.4:
+                raise_amount = min(to_call * 3, my_chips)
+                raise_amount = max(raise_amount, min_raise)
+                return AIThought(
+                    action='raise', amount=raise_amount,
+                    thought=f'3-bet: {combo} at {position} (3bet freq {three_bet_f:.0%})',
+                    chat_message=_chat('raise'),
+                )
+
+            if call_f > 0 and random.random() < call_f:
+                return AIThought(
+                    action='call', amount=0,
+                    thought=f'Call raise: {combo} at {position} ({call_f:.0%})',
+                    chat_message=_chat('call'),
+                )
+
+            return AIThought(
+                action='fold', amount=0,
+                thought=f'Fold pre-flop: {combo} at {position} (call_f={call_f:.0%})',
+                chat_message=_chat('fold'),
+            )
+
+    # ── Post-flop ─────────────────────────────────────────────────────────────
+
+    def _decide_postflop(
+        self,
+        my_hand: List[Card],
+        community: List[Card],
+        active_opponents: int,
+        to_call: int,
+        can_check: bool,
+        pot: int,
+        min_raise: int,
+        my_chips: int,
+    ) -> AIThought:
+        # Monte Carlo equity estimation
+        num_opp = max(1, active_opponents)
+        equity = estimate_equity(my_hand, community, num_opp, n_sim=self.N_SIM_POSTFLOP)
+
+        # Board texture
+        texture: BoardTexture = analyze_board(community)
+
+        # Pot odds (how much equity we need to profitably call)
+        if to_call > 0:
+            pot_odds = to_call / (pot + to_call + 1e-6)
+        else:
+            pot_odds = 0.0
+
+        # ── Bet sizing based on texture ──────────────────────────────────────
+        # Dry boards → smaller sizing; wet boards → larger sizing
+        if texture.wetness >= 0.5:
+            bet_fraction = 0.66  # 2/3 pot on wet boards
+            value_threshold = 0.70
+        else:
+            bet_fraction = 0.33  # 1/3 pot on dry boards
+            value_threshold = 0.65
+
+        bet_size = max(int(pot * bet_fraction), min_raise)
+        bet_size = min(bet_size, my_chips)
+
+        # GTO bluff frequency: bet_size / (pot + 2 * bet_size)
+        bluff_freq = bet_size / (pot + 2 * bet_size + 1e-6)
+
+        thought_base = (
+            f'equity={equity:.0%} pot_odds={pot_odds:.0%} '
+            f'wet={texture.wetness:.2f} bluff_f={bluff_freq:.0%}'
+        )
+
+        # ── Decision tree ────────────────────────────────────────────────────
+        if can_check:
+            # No bet to face
+            if equity >= value_threshold:
+                # Value bet
+                return AIThought(
+                    action='raise', amount=bet_size,
+                    thought=f'Value bet: {thought_base}',
+                    chat_message=_chat('raise'),
+                )
+            if equity < 0.30 and random.random() < bluff_freq:
+                # Bluff with balanced frequency
+                return AIThought(
+                    action='raise', amount=bet_size,
+                    thought=f'Bluff: {thought_base}',
+                    chat_message=_chat('raise'),
+                )
+            return AIThought(
+                action='check', amount=0,
+                thought=f'Check: {thought_base}',
+                chat_message=_chat('check'),
+            )
+        else:
+            # Facing a bet
+            if equity >= value_threshold and equity > pot_odds + 0.10:
+                # Re-raise for value
+                re_raise = min(int(pot * bet_fraction * 1.5), my_chips)
+                re_raise = max(re_raise, min_raise)
+                if re_raise <= to_call or my_chips <= to_call:
+                    # Not enough chips to raise — just call
+                    return AIThought(
+                        action='call', amount=0,
+                        thought=f'Call (value): {thought_base}',
+                        chat_message=_chat('call'),
+                    )
+                return AIThought(
+                    action='raise', amount=re_raise,
+                    thought=f'Value raise: {thought_base}',
+                    chat_message=_chat('raise'),
+                )
+
+            if equity > pot_odds + 0.08:
+                # Profitable call by equity
+                return AIThought(
+                    action='call', amount=0,
+                    thought=f'Call (odds): {thought_base}',
+                    chat_message=_chat('call'),
+                )
+
+            if equity > pot_odds and random.random() < 0.35:
+                # Marginal call — mixed strategy
+                return AIThought(
+                    action='call', amount=0,
+                    thought=f'Marginal call: {thought_base}',
+                    chat_message=_chat('call'),
+                )
+
+            if equity < 0.20 and random.random() < bluff_freq * 0.5:
+                # Bluff raise even when facing a bet (semi-bluff territory)
+                bluff_raise = min(int(pot * 0.66), my_chips)
+                bluff_raise = max(bluff_raise, min_raise)
+                if bluff_raise > to_call and my_chips > to_call:
+                    return AIThought(
+                        action='raise', amount=bluff_raise,
+                        thought=f'Semi-bluff raise: {thought_base}',
+                        chat_message=_chat('raise'),
+                    )
+
+            return AIThought(
+                action='fold', amount=0,
+                thought=f'Fold: {thought_base}',
+                chat_message=_chat('fold'),
+            )

--- a/backend/src/ai/preflop_ranges.py
+++ b/backend/src/ai/preflop_ranges.py
@@ -1,0 +1,286 @@
+"""
+Pre-flop range tables for 6-max Texas Hold'em.
+
+Provides position-based open-raise and call frequencies derived from
+standard GTO 6-max ranges (solver-approximated).
+
+No external dependencies — all data is inlined as dicts.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..engine import Card, Rank
+
+logger = logging.getLogger(__name__)
+
+# ─── Hand combo helpers ────────────────────────────────────────────────────────
+
+def get_hand_combo(c1: Card, c2: Card) -> str:
+    """
+    Return a canonical hand combo string.
+
+    Examples: 'AA', 'AKs', 'T9o', '72o'
+    - Pairs: just the rank twice, e.g. 'QQ'
+    - Suited: higher rank first + 's', e.g. 'AKs'
+    - Offsuit: higher rank first + 'o', e.g. 'AKo'
+    """
+    r1, r2 = c1.rank.value, c2.rank.value
+    # Ensure higher rank comes first
+    if r1 < r2:
+        r1, r2 = r2, r1
+        c1, c2 = c2, c1
+
+    rank_char = {14: 'A', 13: 'K', 12: 'Q', 11: 'J', 10: 'T',
+                 9: '9', 8: '8', 7: '7', 6: '6', 5: '5',
+                 4: '4', 3: '3', 2: '2'}
+
+    s1 = rank_char.get(r1, str(r1))
+    s2 = rank_char.get(r2, str(r2))
+
+    if r1 == r2:
+        return s1 + s2           # pair: 'AA', 'TT', etc.
+    suited = c1.suit == c2.suit
+    return s1 + s2 + ('s' if suited else 'o')
+
+
+def get_position(player_idx: int, dealer_idx: int, total: int) -> str:
+    """
+    Return position name for a player relative to the dealer button.
+
+    Positions for 6-max (6 players):
+      0 seats from dealer → BTN
+      1 seat  from dealer → SB
+      2 seats from dealer → BB
+      3 seats from dealer → EP  (UTG)
+      4 seats from dealer → MP  (HJ)
+      5 seats from dealer → CO
+
+    For fewer players the table is compressed accordingly.
+    """
+    offset = (player_idx - dealer_idx) % total
+    if total >= 6:
+        mapping = {0: 'BTN', 1: 'SB', 2: 'BB', 3: 'EP', 4: 'MP', 5: 'CO'}
+    elif total == 5:
+        mapping = {0: 'BTN', 1: 'SB', 2: 'BB', 3: 'EP', 4: 'CO'}
+    elif total == 4:
+        mapping = {0: 'BTN', 1: 'SB', 2: 'BB', 3: 'CO'}
+    elif total == 3:
+        mapping = {0: 'BTN', 1: 'SB', 2: 'BB'}
+    else:
+        mapping = {0: 'BTN', 1: 'BB'}
+    return mapping.get(offset, 'EP')
+
+
+# ─── Range data ────────────────────────────────────────────────────────────────
+# Format: combo -> open-raise frequency (0.0–1.0)
+# Based on standard 6-max GTO solver approximations.
+# Combos not listed default to 0.0.
+
+# BTN (Button) — widest range, ~65% of hands
+_BTN_OPEN: dict[str, float] = {
+    # Pairs
+    'AA': 1.0, 'KK': 1.0, 'QQ': 1.0, 'JJ': 1.0, 'TT': 1.0,
+    '99': 1.0, '88': 1.0, '77': 1.0, '66': 1.0, '55': 1.0,
+    '44': 1.0, '33': 0.9, '22': 0.85,
+    # Ax suited
+    'AKs': 1.0, 'AQs': 1.0, 'AJs': 1.0, 'ATs': 1.0,
+    'A9s': 1.0, 'A8s': 1.0, 'A7s': 1.0, 'A6s': 1.0,
+    'A5s': 1.0, 'A4s': 1.0, 'A3s': 1.0, 'A2s': 1.0,
+    # Kx suited
+    'KQs': 1.0, 'KJs': 1.0, 'KTs': 1.0, 'K9s': 1.0,
+    'K8s': 0.8, 'K7s': 0.7, 'K6s': 0.6, 'K5s': 0.55,
+    # Qx suited
+    'QJs': 1.0, 'QTs': 1.0, 'Q9s': 0.9, 'Q8s': 0.7, 'Q7s': 0.5,
+    # Jx suited
+    'JTs': 1.0, 'J9s': 0.9, 'J8s': 0.7, 'J7s': 0.5,
+    # Tx suited
+    'T9s': 1.0, 'T8s': 0.85, 'T7s': 0.6,
+    # Connectors suited
+    '98s': 1.0, '97s': 0.75, '87s': 0.9, '86s': 0.6,
+    '76s': 0.9, '75s': 0.55, '65s': 0.85, '64s': 0.4,
+    '54s': 0.75, '53s': 0.4, '43s': 0.5, '42s': 0.35,
+    '32s': 0.3,
+    # Ax offsuit
+    'AKo': 1.0, 'AQo': 1.0, 'AJo': 1.0, 'ATo': 1.0,
+    'A9o': 0.9, 'A8o': 0.75, 'A7o': 0.6, 'A6o': 0.5,
+    'A5o': 0.7, 'A4o': 0.6, 'A3o': 0.5, 'A2o': 0.4,
+    # Kx offsuit
+    'KQo': 1.0, 'KJo': 1.0, 'KTo': 0.9, 'K9o': 0.7,
+    'K8o': 0.5, 'K7o': 0.4,
+    # Qx offsuit
+    'QJo': 0.9, 'QTo': 0.75, 'Q9o': 0.55,
+    # Jx offsuit
+    'JTo': 0.8, 'J9o': 0.55,
+    # Tx offsuit
+    'T9o': 0.65, 'T8o': 0.45,
+    # Misc
+    '98o': 0.55, '87o': 0.4,
+}
+
+# CO (Cutoff) — ~50% of hands
+_CO_OPEN: dict[str, float] = {
+    'AA': 1.0, 'KK': 1.0, 'QQ': 1.0, 'JJ': 1.0, 'TT': 1.0,
+    '99': 1.0, '88': 1.0, '77': 1.0, '66': 0.9, '55': 0.8,
+    '44': 0.7, '33': 0.6, '22': 0.5,
+    'AKs': 1.0, 'AQs': 1.0, 'AJs': 1.0, 'ATs': 1.0,
+    'A9s': 1.0, 'A8s': 0.9, 'A7s': 0.8, 'A6s': 0.7,
+    'A5s': 1.0, 'A4s': 0.9, 'A3s': 0.8, 'A2s': 0.7,
+    'KQs': 1.0, 'KJs': 1.0, 'KTs': 1.0, 'K9s': 0.9,
+    'K8s': 0.7, 'K7s': 0.55,
+    'QJs': 1.0, 'QTs': 1.0, 'Q9s': 0.8, 'Q8s': 0.55,
+    'JTs': 1.0, 'J9s': 0.8, 'J8s': 0.55,
+    'T9s': 1.0, 'T8s': 0.75,
+    '98s': 0.9, '87s': 0.8, '76s': 0.75, '65s': 0.7,
+    '54s': 0.65, '43s': 0.4,
+    'AKo': 1.0, 'AQo': 1.0, 'AJo': 1.0, 'ATo': 0.9,
+    'A9o': 0.75, 'A8o': 0.6, 'A7o': 0.45, 'A5o': 0.55,
+    'KQo': 1.0, 'KJo': 0.9, 'KTo': 0.75, 'K9o': 0.5,
+    'QJo': 0.8, 'QTo': 0.6, 'Q9o': 0.4,
+    'JTo': 0.7, 'J9o': 0.45,
+    'T9o': 0.5, '98o': 0.4,
+}
+
+# MP (Middle position / HJ) — ~35%
+_MP_OPEN: dict[str, float] = {
+    'AA': 1.0, 'KK': 1.0, 'QQ': 1.0, 'JJ': 1.0, 'TT': 1.0,
+    '99': 1.0, '88': 0.9, '77': 0.8, '66': 0.6, '55': 0.5,
+    '44': 0.35, '33': 0.25, '22': 0.2,
+    'AKs': 1.0, 'AQs': 1.0, 'AJs': 1.0, 'ATs': 1.0,
+    'A9s': 0.9, 'A8s': 0.75, 'A7s': 0.6, 'A6s': 0.5,
+    'A5s': 0.8, 'A4s': 0.7, 'A3s': 0.55, 'A2s': 0.45,
+    'KQs': 1.0, 'KJs': 1.0, 'KTs': 0.9, 'K9s': 0.7,
+    'K8s': 0.5,
+    'QJs': 1.0, 'QTs': 0.9, 'Q9s': 0.65,
+    'JTs': 0.9, 'J9s': 0.65,
+    'T9s': 0.85, 'T8s': 0.55,
+    '98s': 0.75, '87s': 0.6, '76s': 0.55, '65s': 0.45,
+    'AKo': 1.0, 'AQo': 1.0, 'AJo': 0.9, 'ATo': 0.75,
+    'A9o': 0.55, 'A8o': 0.4,
+    'KQo': 0.9, 'KJo': 0.75, 'KTo': 0.55,
+    'QJo': 0.65, 'QTo': 0.45,
+    'JTo': 0.55,
+}
+
+# EP (Early position / UTG) — ~22%
+_EP_OPEN: dict[str, float] = {
+    'AA': 1.0, 'KK': 1.0, 'QQ': 1.0, 'JJ': 1.0, 'TT': 1.0,
+    '99': 0.9, '88': 0.75, '77': 0.55, '66': 0.35, '55': 0.25,
+    '44': 0.15, '33': 0.1, '22': 0.1,
+    'AKs': 1.0, 'AQs': 1.0, 'AJs': 1.0, 'ATs': 0.9,
+    'A9s': 0.7, 'A8s': 0.55, 'A7s': 0.4, 'A5s': 0.6, 'A4s': 0.45,
+    'A3s': 0.35, 'A2s': 0.25,
+    'KQs': 1.0, 'KJs': 0.9, 'KTs': 0.75, 'K9s': 0.5,
+    'QJs': 0.85, 'QTs': 0.7,
+    'JTs': 0.8, 'J9s': 0.5,
+    'T9s': 0.65, 'T8s': 0.4,
+    '98s': 0.55, '87s': 0.4, '76s': 0.35,
+    'AKo': 1.0, 'AQo': 0.95, 'AJo': 0.75, 'ATo': 0.55,
+    'A9o': 0.35,
+    'KQo': 0.8, 'KJo': 0.6, 'KTo': 0.4,
+    'QJo': 0.5, 'QTo': 0.3,
+    'JTo': 0.4,
+}
+
+# SB (Small blind) — complex (includes limp), simplified as open freq ~45%
+_SB_OPEN: dict[str, float] = {
+    'AA': 1.0, 'KK': 1.0, 'QQ': 1.0, 'JJ': 1.0, 'TT': 1.0,
+    '99': 1.0, '88': 1.0, '77': 0.9, '66': 0.8, '55': 0.75,
+    '44': 0.65, '33': 0.55, '22': 0.5,
+    'AKs': 1.0, 'AQs': 1.0, 'AJs': 1.0, 'ATs': 1.0,
+    'A9s': 0.9, 'A8s': 0.8, 'A7s': 0.7, 'A6s': 0.65,
+    'A5s': 1.0, 'A4s': 0.9, 'A3s': 0.8, 'A2s': 0.7,
+    'KQs': 1.0, 'KJs': 1.0, 'KTs': 0.95, 'K9s': 0.8,
+    'K8s': 0.65, 'K7s': 0.55, 'K6s': 0.45,
+    'QJs': 1.0, 'QTs': 0.95, 'Q9s': 0.8, 'Q8s': 0.6,
+    'JTs': 1.0, 'J9s': 0.85, 'J8s': 0.6,
+    'T9s': 0.95, 'T8s': 0.75, 'T7s': 0.5,
+    '98s': 0.85, '87s': 0.75, '76s': 0.7, '65s': 0.65,
+    '54s': 0.6, '43s': 0.45,
+    'AKo': 1.0, 'AQo': 1.0, 'AJo': 0.95, 'ATo': 0.85,
+    'A9o': 0.7, 'A8o': 0.6, 'A7o': 0.5, 'A5o': 0.65, 'A4o': 0.55,
+    'KQo': 1.0, 'KJo': 0.9, 'KTo': 0.75, 'K9o': 0.55,
+    'QJo': 0.8, 'QTo': 0.65, 'Q9o': 0.45,
+    'JTo': 0.7, 'J9o': 0.5,
+    'T9o': 0.6, '98o': 0.45,
+}
+
+# BB (Big blind) — defense frequency vs single raise (~55% calls/3-bets)
+# Listed as CALL frequency when facing a single open raise
+_BB_CALL: dict[str, float] = {
+    'AA': 0.0,  # always 3-bet (handled separately)
+    'KK': 0.0, 'QQ': 0.0, 'JJ': 0.0,  # mostly 3-bet
+    'TT': 0.7, '99': 0.8, '88': 0.85, '77': 0.9, '66': 0.9,
+    '55': 0.85, '44': 0.8, '33': 0.75, '22': 0.7,
+    'AKs': 0.0, 'AQs': 0.0,  # 3-bet
+    'AJs': 0.85, 'ATs': 0.9, 'A9s': 0.9, 'A8s': 0.85,
+    'A7s': 0.8, 'A6s': 0.75, 'A5s': 0.9, 'A4s': 0.85, 'A3s': 0.8, 'A2s': 0.75,
+    'KQs': 0.85, 'KJs': 0.9, 'KTs': 0.9, 'K9s': 0.85, 'K8s': 0.7,
+    'QJs': 0.9, 'QTs': 0.9, 'Q9s': 0.8, 'Q8s': 0.65,
+    'JTs': 0.9, 'J9s': 0.8, 'J8s': 0.65,
+    'T9s': 0.85, 'T8s': 0.75, 'T7s': 0.55,
+    '98s': 0.8, '97s': 0.65, '87s': 0.75, '86s': 0.55,
+    '76s': 0.7, '75s': 0.5, '65s': 0.65, '54s': 0.6,
+    'AKo': 0.2, 'AQo': 0.5, 'AJo': 0.8, 'ATo': 0.85,
+    'A9o': 0.75, 'A8o': 0.65, 'A7o': 0.55, 'A5o': 0.65,
+    'KQo': 0.8, 'KJo': 0.8, 'KTo': 0.75, 'K9o': 0.6,
+    'QJo': 0.75, 'QTo': 0.65, 'Q9o': 0.5,
+    'JTo': 0.7, 'J9o': 0.55,
+    'T9o': 0.6, '98o': 0.5, '87o': 0.4,
+}
+
+# Open-raise tables indexed by position
+_OPEN_TABLES: dict[str, dict[str, float]] = {
+    'BTN': _BTN_OPEN,
+    'CO':  _CO_OPEN,
+    'MP':  _MP_OPEN,
+    'EP':  _EP_OPEN,
+    'SB':  _SB_OPEN,
+    'BB':  {},  # BB doesn't open-raise (posts)
+}
+
+# Call-vs-raise tables (facing a single open from any position)
+# Simplified: EP/MP/CO/BTN call ~same range when OOP
+_CALL_VS_RAISE: dict[str, float] = {
+    'AA': 0.0, 'KK': 0.0, 'QQ': 0.05,  # 3-bet these
+    'JJ': 0.4, 'TT': 0.7, '99': 0.8, '88': 0.85, '77': 0.85,
+    '66': 0.8, '55': 0.7, '44': 0.6, '33': 0.5, '22': 0.4,
+    'AKs': 0.0, 'AQs': 0.3, 'AJs': 0.7, 'ATs': 0.8,
+    'A9s': 0.75, 'A8s': 0.7, 'A7s': 0.6, 'A6s': 0.5,
+    'A5s': 0.8, 'A4s': 0.7, 'A3s': 0.6, 'A2s': 0.5,
+    'KQs': 0.65, 'KJs': 0.75, 'KTs': 0.8, 'K9s': 0.65,
+    'QJs': 0.75, 'QTs': 0.75, 'Q9s': 0.6,
+    'JTs': 0.8, 'J9s': 0.65, 'J8s': 0.5,
+    'T9s': 0.75, 'T8s': 0.6,
+    '98s': 0.65, '87s': 0.55, '76s': 0.5, '65s': 0.45,
+    'AKo': 0.15, 'AQo': 0.6, 'AJo': 0.7, 'ATo': 0.65,
+    'A9o': 0.5, 'A8o': 0.4,
+    'KQo': 0.6, 'KJo': 0.6, 'KTo': 0.45,
+    'QJo': 0.55, 'QTo': 0.4,
+    'JTo': 0.5,
+}
+
+
+# ─── Public API ────────────────────────────────────────────────────────────────
+
+def preflop_open_freq(combo: str, position: str) -> float:
+    """
+    Return the open-raise frequency for the given combo and position.
+
+    Returns 0.0 for combos / positions not in the table.
+    """
+    table = _OPEN_TABLES.get(position, {})
+    return table.get(combo, 0.0)
+
+
+def preflop_call_freq(combo: str, position: str) -> float:
+    """
+    Return the call (vs single raise) frequency for the given combo.
+
+    BB uses the BB-specific defence table; all other positions use the
+    generic call-vs-raise table.
+    """
+    if position == 'BB':
+        return _BB_CALL.get(combo, 0.0)
+    return _CALL_VS_RAISE.get(combo, 0.0)

--- a/frontend/src/components/layout/LLMConfigBar.tsx
+++ b/frontend/src/components/layout/LLMConfigBar.tsx
@@ -11,6 +11,7 @@ const OLLAMA_MODELS = ['qwen2.5:7b', 'qwen2.5:14b', 'llama3.1:8b'];
 
 const ENGINE_OPTIONS: { value: LLMEngine; label: string }[] = [
   { value: 'rule-based', label: 'RULE-BASED' },
+  { value: 'gto',        label: 'GTO' },
   { value: 'ollama',     label: 'OLLAMA' },
   { value: 'qwen-plus',  label: 'QWEN-PLUS' },
   { value: 'qwen-max',   label: 'QWEN-MAX' },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -34,7 +34,7 @@ export interface GameState {
   max_raises_per_street: number;
 }
 
-export type LLMEngine = 'rule-based' | 'ollama' | 'qwen-plus' | 'qwen-max';
+export type LLMEngine = 'rule-based' | 'gto' | 'ollama' | 'qwen-plus' | 'qwen-max';
 
 export interface LLMConfig {
   engine: LLMEngine;


### PR DESCRIPTION
Security audit confirms full information isolation:
- Bots receive only masked game state via get_public_game_state(bot_id)
- Community cards always visible; opponent hands always hidden
- OS entropy seed added at startup for unpredictable shuffles

New backend modules (Part 1-3):
- preflop_ranges.py: 6-max GTO open/call frequency tables by position
- equity.py: Monte Carlo equity estimator (~400 sims ≈ 5ms, no external libs)
- board_texture.py: wetness / flush / straight / paired classification
- gto_strategy.py: GTOBotStrategy with mixed-frequency pre-flop + equity-based postflop
- gto_coach.py: GTOCoach (no LLM) with Chinese analysis, same interface as AICoach

Integration changes:
- _build_strategy() now returns GTOCoach for both 'gto' and 'rule-based' engines so the human always has access to ASK AI hints without needing an LLM
- 'gto' added to LLMEngine type and ENGINE_OPTIONS in LLMConfigBar