### PR TITLE
feat: responsive layout, blind bug fix, ActionBar UX, card animations…

### DIFF
--- a/backend/src/engine.py
+++ b/backend/src/engine.py
@@ -369,8 +369,11 @@ class PokerEngine:
             and bool(getattr(self, 'winners', []))
         )
 
-        for p in self.players:
+        for i, p in enumerate(self.players):
             p_data = p.to_dict()
+            # Augment positional badges so the frontend can render BTN/SB/BB correctly
+            p_data["is_dealer"] = (i == self.dealer_idx)
+            p_data["is_turn"] = (i == self.current_player_idx)
             # Mask hand if not the observer, unless this is a real showdown and the player
             # stayed in (didn't fold) — folded players' cards are never revealed.
             if p.id != observer_id and not (is_actual_showdown and p.is_active):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Silkscreen:wght@400;700&family=VT323&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Silkscreen:wght@400;700&family=VT323&family=Noto+Sans+SC:wght@400;700&display=swap" rel="stylesheet">
     <title>CYBER HOLD'EM</title>
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
 
   return (
     <div style={{
-      minHeight: '100vh',
+      height: '100vh',
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
@@ -100,7 +100,8 @@ function App() {
         flexDirection: 'column',
         alignItems: 'center',
         width: '100%',
-        overflowY: 'auto',
+        overflow: 'hidden',
+        minHeight: 0,
       }}>
         {!gameState ? (
           /* Start Screen */
@@ -142,7 +143,9 @@ function App() {
         ) : (
           <>
             {/* Poker table */}
-            <PokerTable gameState={gameState} />
+            <div style={{ flex: 1, minHeight: 0, width: '100%', display: 'flex', flexDirection: 'column' }}>
+              <PokerTable gameState={gameState} handCount={handCount} />
+            </div>
 
             {/* Action bar */}
             <ActionBar

--- a/frontend/src/components/card/Card.tsx
+++ b/frontend/src/components/card/Card.tsx
@@ -12,6 +12,7 @@ interface CardProps {
   suit?: string;
   glow?: CardGlow;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 interface SizeSpec {
@@ -93,6 +94,7 @@ const Card: React.FC<CardProps> = ({
   suit,
   glow = 'none',
   className = '',
+  style,
 }) => {
   const spec = SIZES[size];
   const isXS = size === 'xs';
@@ -121,6 +123,7 @@ const Card: React.FC<CardProps> = ({
     opacity: variant === 'placeholder' ? 0.2 : 1,
     overflow: 'hidden',
     ...xsInlineStyle,
+    ...style,
   };
 
   // === PLACEHOLDER ===

--- a/frontend/src/components/layout/ActionBar.tsx
+++ b/frontend/src/components/layout/ActionBar.tsx
@@ -56,8 +56,6 @@ const ActionBar: React.FC<ActionBarProps> = ({
     setRaiseAmount(String(clamp(base + delta, minRaise, maxRaise)));
   }, [currentAmount, minRaise, maxRaise]);
 
-  const cycleStep = () => setStepIdx(i => (i + 1) % STEPS.length);
-
   // ─── Raise submit ──────────────────────────────────────────────────────────
   function handleRaise() {
     const amt = parseInt(raiseAmount, 10);
@@ -106,14 +104,21 @@ const ActionBar: React.FC<ActionBarProps> = ({
   return (
     <div style={{
       width: '100%',
-      maxWidth: 1100,
       display: 'flex',
-      gap: 10,
-      justifyContent: 'center',
-      flexWrap: 'wrap',
       alignItems: 'flex-end',
       padding: '12px 8px 8px',
+      gap: 8,
     }}>
+
+      {/* ── Main action cluster (centered) ── */}
+      <div style={{
+        flex: 1,
+        display: 'flex',
+        gap: 10,
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        alignItems: 'flex-end',
+      }}>
 
       {/* ── FOLD ── */}
       <button
@@ -220,13 +225,30 @@ const ActionBar: React.FC<ActionBarProps> = ({
             ▲
           </button>
 
-          {/* Step cycle button */}
+          {/* Step control: ◀ STEP N ▶ */}
           <button
             className="abtn"
-            style={{ fontSize: 8, padding: '5px 9px', borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
-            onClick={cycleStep}
+            style={{ fontSize: 11, padding: '4px 8px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
+            onClick={() => setStepIdx(i => (i - 1 + STEPS.length) % STEPS.length)}
           >
-            STEP {step}▸
+            ◀
+          </button>
+          <div style={{
+            fontSize: 8,
+            color: 'var(--gold-d)',
+            fontFamily: 'var(--font-label)',
+            alignSelf: 'center',
+            whiteSpace: 'nowrap',
+            letterSpacing: 1,
+          }}>
+            STEP {step}
+          </div>
+          <button
+            className="abtn"
+            style={{ fontSize: 11, padding: '4px 8px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
+            onClick={() => setStepIdx(i => (i + 1) % STEPS.length)}
+          >
+            ▶
           </button>
 
           {/* Fix 8: min~max range hint */}
@@ -250,15 +272,6 @@ const ActionBar: React.FC<ActionBarProps> = ({
             RAISE ▲<Hint k="R" />
           </button>
 
-          {/* Fix 6: ALL IN button */}
-          <button
-            className="abtn abtn-raise"
-            disabled={disabled}
-            onClick={() => onAction('allin', 0)}
-            style={{ borderColor: '#ffcc00', color: '#ffcc00' }}
-          >
-            ALL IN ▲ ${human?.chips}<Hint k="A" />
-          </button>
         </>
       )}
 
@@ -270,6 +283,29 @@ const ActionBar: React.FC<ActionBarProps> = ({
       >
         {isRequestingAdvice ? '◈ THINKING...' : '◈ ASK AI'}
       </button>
+
+      </div>{/* end main cluster */}
+
+      {/* ── ALL IN — danger zone, far right ── */}
+      {canRaise && (
+        <button
+          className="abtn"
+          disabled={disabled}
+          onClick={() => onAction('allin', 0)}
+          style={{
+            borderColor: '#aa2222',
+            color: '#ff4444',
+            fontSize: 7,
+            padding: '6px 10px',
+            flexShrink: 0,
+            alignSelf: 'flex-end',
+            lineHeight: 1.5,
+          }}
+        >
+          ALL IN<br />${human?.chips}<Hint k="A" />
+        </button>
+      )}
+
     </div>
   );
 };

--- a/frontend/src/components/layout/LLMConfigBar.tsx
+++ b/frontend/src/components/layout/LLMConfigBar.tsx
@@ -63,7 +63,6 @@ const LLMConfigBar: React.FC<LLMConfigBarProps> = ({ config, onConfigChange }) =
   return (
     <div style={{
       width: '100%',
-      maxWidth: 1100,
       padding: '0 8px 14px',
     }}>
       <div style={{

--- a/frontend/src/components/table/CommunityCards.tsx
+++ b/frontend/src/components/table/CommunityCards.tsx
@@ -12,20 +12,23 @@ const CommunityCards: React.FC<CommunityCardsProps> = ({ cards }) => {
       {Array.from({ length: 5 }, (_, i) => {
         const card = cards[i];
         if (card) {
+          // Key changes from 'ph-i' → 'rank-suit' when card is revealed,
+          // forcing remount and replaying the cardReveal animation.
           return (
             <Card
-              key={i}
+              key={`${card.rank}-${card.suit}`}
               size="lg"
               variant="face-up"
               rank={card.rank}
               suit={card.suit}
               glow="gold"
+              style={{ animation: `cardReveal 0.32s ease-out ${i * 55}ms both` }}
             />
           );
         }
         return (
           <Card
-            key={i}
+            key={`ph-${i}`}
             size="lg"
             variant="placeholder"
           />

--- a/frontend/src/components/table/HoleCards.tsx
+++ b/frontend/src/components/table/HoleCards.tsx
@@ -5,9 +5,10 @@ import Card from '../card/Card';
 interface HoleCardsProps {
   cards: (CardType | null)[];
   isHumanTurn: boolean; // Fix 7: show red glow only when it's the human's turn to act
+  handCount: number;    // Changes every new hand → triggers re-animation via key
 }
 
-const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn }) => {
+const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn, handCount }) => {
   return (
     <div style={{
       position: 'absolute',
@@ -36,15 +37,16 @@ const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn }) => {
         {cards.slice(0, 2).map((card, i) =>
           card ? (
             <Card
-              key={i}
+              key={`${handCount}-${i}`}
               size="md"
               variant="face-up"
               rank={card.rank}
               suit={card.suit}
               glow={isHumanTurn ? 'red' : 'none'}
+              style={{ animation: `cardDeal 0.4s ease-out ${i * 110}ms both` }}
             />
           ) : (
-            <Card key={i} size="md" variant="face-down" />
+            <Card key={`${handCount}-${i}`} size="md" variant="face-down" />
           )
         )}
       </div>

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -8,6 +8,7 @@ import HoleCards from './HoleCards';
 
 interface PokerTableProps {
   gameState: GameState;
+  handCount: number;
 }
 
 /**
@@ -28,7 +29,7 @@ function getBadge(
   return undefined;
 }
 
-const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
+const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
   const { players, community_cards, pot, state, current_player_idx } = gameState;
 
   // players[0] = human; bots = players[1..5]
@@ -48,22 +49,22 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
   return (
     <div style={{
       width: '100%',
-      maxWidth: 1100,
+      flex: 1,
       padding: '12px 8px',
-      display: 'grid',
-      gridTemplateColumns: '190px 1fr 190px',
-      gridTemplateRows: 'auto',
+      display: 'flex',
+      flexDirection: 'column',
     }}>
-      {/* Felt wrap — spans all 3 columns */}
+      {/* Felt wrap */}
       <div style={{
-        gridColumn: '1 / 4',
-        gridRow: '1 / 3',
+        flex: 1,
         position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
       }}>
         {/* The green felt */}
         <div style={{
           width: '100%',
-          minHeight: 560,
+          flex: 1,
           background: 'radial-gradient(ellipse 80% 70% at 50% 42%, var(--felt-c) 0%, #122012 55%, var(--felt-e) 100%)',
           border: '5px solid var(--gold)',
           boxShadow: '0 0 0 2px var(--gold-d), inset 0 0 60px rgba(0,0,0,0.45), 0 0 40px rgba(200,160,64,0.06)',
@@ -153,6 +154,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState }) => {
           {humanPlayer && (
             <HoleCards
               cards={humanPlayer.hand}
+              handCount={handCount}
               isHumanTurn={
                 current_player_idx === 0 &&
                 state !== 'SHOWDOWN' &&

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,9 +31,9 @@
 
   /* === Typography === */
   --font-rank:  Georgia, 'Times New Roman', serif;
-  --font-ui:    'Silkscreen', monospace;
-  --font-ai:    'VT323', monospace;
-  --font-label: 'Press Start 2P', monospace;
+  --font-ui:    'Silkscreen', 'Noto Sans SC', monospace;
+  --font-ai:    'VT323', 'Noto Sans SC', monospace;
+  --font-label: 'Press Start 2P', 'Noto Sans SC', monospace;
 
   /* === Shadows === */
   --shadow-card-lg: 4px 4px 0 #000;
@@ -116,6 +116,20 @@
 @keyframes numUpdate {
   0%   { color: #ffff88; transform: scale(1.25); }
   100% { color: inherit; transform: scale(1); }
+}
+
+/* Hole card deal — swoops in from above with slight rotation & bounce */
+@keyframes cardDeal {
+  0%   { opacity: 0; transform: translateY(-22px) rotate(-4deg); }
+  65%  { opacity: 1; transform: translateY(2px) rotate(0.5deg); }
+  100% { opacity: 1; transform: translateY(0) rotate(0deg); }
+}
+
+/* Community card reveal — pops up from below with a quick scale bounce */
+@keyframes cardReveal {
+  0%   { opacity: 0; transform: scale(0.65) translateY(10px); }
+  70%  { opacity: 1; transform: scale(1.06) translateY(-1px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
 }
 
 /* Hide native number input spinners (Part 1) */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,6 +15,7 @@ export interface Player {
   is_all_in: boolean;
   has_acted: boolean;
   is_dealer: boolean;
+  is_turn: boolean;
 }
 
 export type GameStreet = 'PREFLOP' | 'FLOP' | 'TURN' | 'RIVER' | 'SHOWDOWN' | 'FINISHED';

--- a/frontend/src/utils/cardDisplay.ts
+++ b/frontend/src/utils/cardDisplay.ts
@@ -1,7 +1,7 @@
 import type { Suit } from '../types';
 
 const RANK_DISPLAY: Record<number, string> = {
-  14: 'A', 13: 'K', 12: 'Q', 11: 'J', 10: 'T',
+  14: 'A', 13: 'K', 12: 'Q', 11: 'J', 10: '10',
   9: '9', 8: '8', 7: '7', 6: '6', 5: '5', 4: '4', 3: '3', 2: '2',
 };
 


### PR DESCRIPTION
…, CJK font

Part 1 — Full-screen layout
- Root div height:100vh, main overflow:hidden; PokerTable flex:1 fills viewport
- Remove maxWidth:1100 cap from PokerTable, ActionBar, LLMConfigBar
- Felt div changes from minHeight:560 to flex:1 so table scales with window

Part 2 — Backend blind position bug
- engine.py get_public_game_state(): loop now uses enumerate(self.players)
- Each player dict gains is_dealer / is_turn fields so frontend BTN/SB/BB badges move correctly every hand
- types.ts Player interface adds is_turn: boolean

Part 3 — ActionBar UX
- ALL IN button moved to far-right danger zone (red border/text, smaller)
- Step control replaced: single STEP N▸ cycle → ◀ STEP N ▶ with separate decrement / increment buttons

Part 4 — Card animations
- CSS keyframes: cardDeal (hole cards) and cardReveal (community cards)
- Card.tsx gains style?: React.CSSProperties prop
- HoleCards: key=${handCount}-${i} forces remount + cardDeal on new hand (staggered 0ms / 110ms)
- CommunityCards: key=rank-suit triggers cardReveal when placeholder flips to real card (staggered 55ms per card)
- handCount threaded App → PokerTable → HoleCards

Part 5 — Chinese font support
- Noto Sans SC added to Google Fonts link in index.html
- --font-ui / --font-ai / --font-label CSS vars include Noto Sans SC fallback

Misc — rank display: 10 shown as '10' instead of 'T'