### PR TITLE
fix: remove unreachable default case in formatAction to fix TS2339

### DIFF
--- a/frontend/src/components/table/ActionAnnouncement.tsx
+++ b/frontend/src/components/table/ActionAnnouncement.tsx
@@ -12,7 +12,6 @@ function formatAction(action: PlayerAction): string {
     case 'call':  return 'CALL';
     case 'raise': return `RAISE $${action.amount}`;
     case 'allin': return 'ALL IN';
-    default:      return action.action.toUpperCase();
   }
 }
 


### PR DESCRIPTION
The switch already covers all union members of PlayerAction['action'], so the default branch was typed as 'never'. Docker's stricter tsc -b caught the .toUpperCase() call on 'never'.