### PR TITLE
feat: enlarge bot PlayerBoxes ~85%, fix Next Hand layout shift

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -157,17 +157,21 @@ function App() {
               showCoach={showCoach}
             />
 
-            {/* Next hand button */}
-            {isGameOver && (
-              <div style={{ padding: '10px 0 6px' }}>
-                <button
-                  className="abtn abtn-raise"
-                  onClick={startNextHand}
-                >
-                  ▶ NEXT HAND
-                </button>
-              </div>
-            )}
+            {/* Next hand button — always rendered, visibility toggled to prevent layout shift */}
+            <div style={{
+              padding: '10px 0 6px',
+              display: 'flex',
+              justifyContent: 'center',
+              visibility: isGameOver ? 'visible' : 'hidden',
+              flexShrink: 0,
+            }}>
+              <button
+                className="abtn abtn-raise"
+                onClick={startNextHand}
+              >
+                ▶ NEXT HAND
+              </button>
+            </div>
 
             {/* LLM config bar */}
             <LLMConfigBar

--- a/frontend/src/components/player/PlayerBox.tsx
+++ b/frontend/src/components/player/PlayerBox.tsx
@@ -34,8 +34,8 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   const boxStyle: React.CSSProperties = {
     background: 'rgba(10, 9, 0, 0.88)',
     border: '2px solid var(--brown)',
-    padding: '12px 16px',
-    width: 220,
+    padding: '20px 28px',
+    width: 400,
     position: 'relative',
     clipPath: 'var(--clip-sm)',
     opacity: isFolded ? 0.3 : 1,
@@ -58,20 +58,20 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
-      gap: 3,
+      gap: 5,
       alignSelf: 'center',
       flexShrink: 0,
     }}>
       {/* Chip pile — key forces remount+animation when bet changes */}
-      <ChipStack key={player.current_bet} amount={player.current_bet} size="md" />
+      <ChipStack key={player.current_bet} amount={player.current_bet} size="lg" />
       {/* Amount label below the stack */}
       <div style={{
         fontFamily: 'var(--font-ui)',
-        fontSize: 8,
+        fontSize: 14,
         color: 'var(--gold)',
         background: '#1a0e00',
         border: '1px solid var(--gold-d)',
-        padding: '2px 6px',
+        padding: '4px 10px',
         whiteSpace: 'nowrap',
       }}>
         <span
@@ -89,7 +89,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
       display: 'flex',
       flexDirection: chipBubbleSide === 'right' ? 'row' : 'row-reverse',
       alignItems: 'center',
-      gap: 6,
+      gap: 10,
     }}>
       {/* Main pbox */}
       <div style={{ ...boxStyle, ...activeBoxStyle }}>
@@ -97,12 +97,12 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         {badge && (
           <div style={{
             position: 'absolute',
-            top: -10,
+            top: -14,
             right: 5,
             background: 'var(--gold)',
             color: '#000',
-            fontSize: 8,
-            padding: '2px 6px',
+            fontSize: 14,
+            padding: '4px 10px',
             fontFamily: 'var(--font-ui)',
             lineHeight: 1.4,
           }}>
@@ -113,9 +113,9 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         {/* Bot name */}
         <div style={{
           fontFamily: 'var(--font-ui)',
-          fontSize: 13,
+          fontSize: 22,
           color: 'var(--gold)',
-          marginBottom: 4,
+          marginBottom: 6,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
@@ -125,9 +125,9 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
         {/* Chips — key replays numUpdate animation when chips change */}
         <div style={{
-          fontSize: 9,
+          fontSize: 16,
           color: 'var(--gold-l)',
-          marginBottom: 3,
+          marginBottom: 5,
           fontFamily: 'var(--font-label)',
         }}>
           <span
@@ -140,7 +140,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
         {/* Status */}
         <div style={{
-          fontSize: 9,
+          fontSize: 16,
           color: status.color,
           fontFamily: 'var(--font-label)',
         }}>
@@ -148,17 +148,17 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         </div>
 
         {/* Cards (face-down or face-up at showdown) */}
-        <div style={{ display: 'flex', gap: 5, marginTop: 6 }}>
+        <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
           {showCards ? (
             <>
               <Card
-                size="sm"
+                size="md"
                 variant="face-up"
                 rank={(player.hand[0] as CardType).rank}
                 suit={(player.hand[0] as CardType).suit}
               />
               <Card
-                size="sm"
+                size="md"
                 variant="face-up"
                 rank={(player.hand[1] as CardType).rank}
                 suit={(player.hand[1] as CardType).suit}
@@ -166,8 +166,8 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
             </>
           ) : (
             <>
-              <Card size="sm" variant="face-down" />
-              <Card size="sm" variant="face-down" />
+              <Card size="md" variant="face-down" />
+              <Card size="md" variant="face-down" />
             </>
           )}
         </div>

--- a/frontend/src/components/table/ChipStack.tsx
+++ b/frontend/src/components/table/ChipStack.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 interface ChipStackProps {
   /** Chip amount to represent visually */
   amount: number;
-  /** 'sm' for player-bet bubbles, 'md' for pot display */
-  size?: 'sm' | 'md';
+  /** 'sm' for small contexts, 'md' for pot display, 'lg' for enlarged bot bet bubbles */
+  size?: 'sm' | 'md' | 'lg';
 }
 
 /**
@@ -41,9 +41,9 @@ const ChipStack: React.FC<ChipStackProps> = ({ amount, size = 'md' }) => {
   const count = getChipCount(amount);
   if (count === 0) return null;
 
-  const W = size === 'sm' ? 28 : 36;  // chip width px
-  const H = size === 'sm' ? 7  : 10;  // chip height px
-  const OVERLAP = size === 'sm' ? -3  : -4; // negative margin to stack chips
+  const W = size === 'lg' ? 52 : size === 'sm' ? 28 : 36;  // chip width px
+  const H = size === 'lg' ? 14 : size === 'sm' ? 7  : 10;  // chip height px
+  const OVERLAP = size === 'lg' ? -6 : size === 'sm' ? -3  : -4; // negative margin to stack chips
 
   return (
     <div

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -128,11 +128,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
           {/* Left bots (3) */}
           <div style={{
             position: 'absolute',
-            left: 12,
-            top: 20,
+            left: 16,
+            top: 28,
             display: 'flex',
             flexDirection: 'column',
-            gap: 14,
+            gap: 20,
           }}>
             {leftBots.map((bot, i) => {
               const playerIdx = i + 1; // bot 0→idx1, bot 1→idx2, bot 2→idx3
@@ -151,11 +151,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
           {/* Right bots (2) */}
           <div style={{
             position: 'absolute',
-            right: 12,
-            top: 20,
+            right: 16,
+            top: 28,
             display: 'flex',
             flexDirection: 'column',
-            gap: 14,
+            gap: 20,
             alignItems: 'flex-end',
           }}>
             {rightBots.map((bot, i) => {


### PR DESCRIPTION
PlayerBox: width 220→400, padding scaled up, name 13→22px, chips/status 9→16px, badge 8→14px, cards sm→md (38×54→62×88), bet bubble chip lg size. ChipStack: add "lg" variant (52×14px) for enlarged bot bet bubbles. PokerTable: bot column offsets 12→16, top 20→28, gap 14→20. App: Next Hand button always rendered with visibility toggle instead of conditional rendering, preventing poker table resize on showdown.