### PR TITLE
feat: badge fix, game-over detection, quit/restart, Chinese/English i18n

### DIFF
--- a/frontend/src/components/ai-coach/AICoachPanel.tsx
+++ b/frontend/src/components/ai-coach/AICoachPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { AICoachAdvice } from '../../types';
 import InlineCard from '../card/InlineCard';
+import { useT } from '../../i18n/I18nContext';
 
 interface AICoachPanelProps {
   advice: AICoachAdvice | null;
@@ -23,6 +24,8 @@ const STAT_COLORS: Record<string, string> = {
 };
 
 const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose }) => {
+  const { t } = useT();
+
   return (
     <div style={{
       position: 'relative',
@@ -56,7 +59,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
           letterSpacing: 2,
           fontFamily: 'var(--font-label)',
         }}>
-          ◈ AI COACH
+          {t('coach.title')}
         </div>
         <button
           onClick={onClose}
@@ -87,7 +90,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
           alignItems: 'center',
         }}>
           <span style={{ animation: 'blink 1s steps(1) infinite' }}>
-            ◈ AI THINKING...
+            {t('coach.thinking')}
           </span>
         </div>
       )}
@@ -105,7 +108,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
               : undefined,
             marginBottom: 16,
           }}>
-            推荐：{advice.recommendation}
+            {t('coach.recommend')}{advice.recommendation}
             {advice.recommendedAmount != null && ` → $${advice.recommendedAmount}`}
           </div>
 
@@ -175,7 +178,7 @@ const AICoachPanel: React.FC<AICoachPanelProps> = ({ advice, isLoading, onClose 
           textAlign: 'center',
           padding: '20px 0',
         }}>
-          点击 ◈ ASK AI 获取建议
+          {t('coach.empty')}
         </div>
       )}
     </div>

--- a/frontend/src/components/layout/ActionBar.tsx
+++ b/frontend/src/components/layout/ActionBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { GameState } from '../../types';
+import { useT } from '../../i18n/I18nContext';
 
 interface ActionBarProps {
   gameState: GameState;
@@ -30,6 +31,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
   disabled,
   showCoach,
 }) => {
+  const { t } = useT();
   const [raiseAmount, setRaiseAmount] = useState<string>('');
   const [stepIdx, setStepIdx] = useState(2); // default step = STEPS[2] = 10
 
@@ -124,7 +126,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           disabled={disabled}
           onClick={() => onAction('fold', 0)}
         >
-          FOLD<Hint k="F" />
+          {t('action.fold')}<Hint k="F" />
         </button>
 
         {/* CHECK — two-line structure keeps height identical to CALL */}
@@ -135,7 +137,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
             disabled={disabled}
             onClick={() => onAction('check', 0)}
           >
-            CHECK<Hint k="C" />
+            {t('action.check')}<Hint k="C" />
             {/* invisible spacer so height matches CALL+odds */}
             <span style={{ fontSize: 6, visibility: 'hidden' }}>0.0:1</span>
           </button>
@@ -149,9 +151,9 @@ const ActionBar: React.FC<ActionBarProps> = ({
             disabled={disabled}
             onClick={() => onAction('call', 0)}
           >
-            CALL ${toCall}<Hint k="C" />
+            {t('action.call')} ${toCall}<Hint k="C" />
             <span style={{ fontSize: 6, visibility: potOdds ? 'visible' : 'hidden', color: 'var(--gold-d)' }}>
-              {potOdds ?? '0.0'}:1 ODDS
+              {potOdds ?? '0.0'}:1 {t('bet.odds')}
             </span>
           </button>
         )}
@@ -163,7 +165,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           disabled={isRequestingAdvice}
           onClick={onAskAI}
         >
-          {isRequestingAdvice ? '◈ THINKING...' : '◈ ASK AI'}
+          {isRequestingAdvice ? t('action.thinking') : t('action.askAi')}
         </button>
 
       </div>
@@ -187,15 +189,15 @@ const ActionBar: React.FC<ActionBarProps> = ({
         {/* Quick-bet buttons */}
         <button className="abtn" style={smBtn} disabled={disabled}
           onClick={() => setQuickBet(Math.round(gameState.pot / 2))}>
-          ½ POT
+          {t('bet.halfPot')}
         </button>
         <button className="abtn" style={smBtn} disabled={disabled}
           onClick={() => setQuickBet(gameState.pot)}>
-          POT
+          {t('bet.pot')}
         </button>
         <button className="abtn" style={smBtn} disabled={disabled}
           onClick={() => setQuickBet(40)}>
-          2×BB
+          {t('bet.2xbb')}
         </button>
 
         {/* Decrement */}
@@ -230,7 +232,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           ◀
         </button>
         <div style={{ fontSize: 7, color: 'var(--gold-d)', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', letterSpacing: 1 }}>
-          STEP {step}
+          {t('bet.step')} {step}
         </div>
         <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
           onClick={() => setStepIdx(i => (i + 1) % STEPS.length)}>
@@ -248,7 +250,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           disabled={disabled || raiseAmount === ''}
           onClick={handleRaise}
         >
-          RAISE ▲<Hint k="R" />
+          {t('action.raise')} ▲<Hint k="R" />
         </button>
 
         {/* ALL IN */}
@@ -258,7 +260,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           onClick={() => onAction('allin', 0)}
           style={{ borderColor: '#aa2222', color: '#ff4444', fontSize: 7, padding: '4px 10px', lineHeight: 1.5 }}
         >
-          ALL IN<br />${human?.chips}<Hint k="A" />
+          {t('action.allin')}<br />${human?.chips}<Hint k="A" />
         </button>
 
       </div>

--- a/frontend/src/components/player/HumanPanel.tsx
+++ b/frontend/src/components/player/HumanPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Player } from '../../types';
+import { useT } from '../../i18n/I18nContext';
 
 interface HumanPanelProps {
   player: Player;
@@ -38,6 +39,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
   totalPlayers,
   isHumanTurn,
 }) => {
+  const { t } = useT();
   const posLabel = derivePositionLabel(playerIdx, dealerIdx, totalPlayers);
   const ip = isInPosition(playerIdx, dealerIdx, totalPlayers);
 
@@ -63,7 +65,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
           marginBottom: 5,
           textAlign: 'center',
         }}>
-          ◈ YOUR TURN
+          ◈ {t('human.yourTurn')}
         </div>
       )}
 
@@ -77,7 +79,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
         marginBottom: 6,
         fontFamily: 'var(--font-label)',
       }}>
-        YOU
+        {t('human.you')}
       </div>
 
       {/* Player name */}
@@ -118,7 +120,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
       }}>
         <span style={{ color: ip ? '#66cc88' : '#cc6666' }}>●</span>
         {posLabel && <span>{posLabel}</span>}
-        <span>{ip ? 'IN POS' : 'OOP'}</span>
+        <span>{ip ? t('human.inPos') : t('human.oop')}</span>
       </div>
 
       {/* Current bet if any */}
@@ -129,7 +131,7 @@ const HumanPanel: React.FC<HumanPanelProps> = ({
           color: '#ffcc00',
           fontFamily: 'var(--font-label)',
         }}>
-          BET: ${player.current_bet}
+          {t('status.bet')}: ${player.current_bet}
         </div>
       )}
     </div>

--- a/frontend/src/components/table/ActionAnnouncement.tsx
+++ b/frontend/src/components/table/ActionAnnouncement.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import type { PlayerAction } from '../../types';
+import { useT } from '../../i18n/I18nContext';
 
 interface ActionAnnouncementProps {
   action: PlayerAction;
 }
 
-function formatAction(action: PlayerAction): string {
+function formatAction(action: PlayerAction, t: (key: string) => string): string {
   switch (action.action) {
-    case 'fold':  return 'FOLD';
-    case 'check': return 'CHECK';
-    case 'call':  return 'CALL';
-    case 'raise': return `RAISE $${action.amount}`;
-    case 'allin': return 'ALL IN';
+    case 'fold':  return t('action.fold');
+    case 'check': return t('action.check');
+    case 'call':  return t('action.call');
+    case 'raise': return `${t('action.raise')} $${action.amount}`;
+    case 'allin': return t('action.allin');
   }
 }
 
@@ -27,8 +28,9 @@ function getActionColor(action: string): string {
 }
 
 const ActionAnnouncement: React.FC<ActionAnnouncementProps> = ({ action }) => {
+  const { t } = useT();
   const color = getActionColor(action.action);
-  const text = formatAction(action);
+  const text = formatAction(action, t);
 
   return (
     <div style={{

--- a/frontend/src/components/table/DealerBadge.tsx
+++ b/frontend/src/components/table/DealerBadge.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useT } from '../../i18n/I18nContext';
 
 interface DealerBadgeProps {
   isDealing: boolean;
@@ -7,12 +8,13 @@ interface DealerBadgeProps {
 }
 
 const DealerBadge: React.FC<DealerBadgeProps> = ({ isDealing, isRevealing, isShowdown }) => {
+  const { t } = useT();
   const active = isDealing || isRevealing;
   const label = isShowdown
-    ? '◈ SHOWDOWN ◈'
+    ? t('dealer.showdown')
     : active
-      ? '◈ DEALING...'
-      : '◈ DEALER';
+      ? t('dealer.dealing')
+      : t('dealer.label');
 
   return (
     <div style={{

--- a/frontend/src/components/table/HoleCards.tsx
+++ b/frontend/src/components/table/HoleCards.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Card as CardType } from '../../types';
 import Card from '../card/Card';
+import { useT } from '../../i18n/I18nContext';
 
 interface HoleCardsProps {
   cards: (CardType | null)[];
@@ -9,6 +10,7 @@ interface HoleCardsProps {
 }
 
 const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn, handCount }) => {
+  const { t } = useT();
   return (
     <div style={{
       position: 'absolute',
@@ -29,7 +31,7 @@ const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn, handCount }) 
         fontFamily: 'var(--font-label)',
         whiteSpace: 'nowrap',
       }}>
-        ▼ YOUR HAND
+        ▼ {t('human.yourHand')}
       </div>
 
       {/* Two hole cards */}

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -8,6 +8,7 @@ import HoleCards from './HoleCards';
 import DealerBadge from './DealerBadge';
 import ActionAnnouncement from './ActionAnnouncement';
 import { useGameStore } from '../../store/useGameStore';
+import { useT } from '../../i18n/I18nContext';
 
 interface PokerTableProps {
   gameState: GameState;
@@ -33,6 +34,7 @@ function getBadge(
 }
 
 const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
+  const { t } = useT();
   const { players, community_cards, pot, state, current_player_idx } = gameState;
 
   // players[0] = human; bots = players[1..5]
@@ -249,7 +251,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                 whiteSpace: 'nowrap',
               }}>
                 <div style={{ fontSize: 7, color: 'var(--gold-d)', letterSpacing: 3, marginBottom: 8, fontFamily: 'var(--font-label)' }}>
-                  ◈ SHOWDOWN ◈
+                  {t('showdown.label')}
                 </div>
                 <div style={{ fontSize: 12, color: 'var(--gold)', letterSpacing: 1, marginBottom: 6, fontFamily: 'var(--font-ui)' }}>
                   {winnerNames}

--- a/frontend/src/components/table/PotDisplay.tsx
+++ b/frontend/src/components/table/PotDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import ChipStack from './ChipStack';
+import { useT } from '../../i18n/I18nContext';
 
 interface PotDisplayProps {
   pot: number;
@@ -7,6 +8,7 @@ interface PotDisplayProps {
 }
 
 const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
+  const { t } = useT();
   // Track whether the pot just grew so we can apply the glow animation
   const prevPot = useRef(pot);
   const [glowing, setGlowing] = useState(false);
@@ -57,7 +59,7 @@ const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
         fontFamily: 'var(--font-label)',
         whiteSpace: 'nowrap',
       }}>
-        ◈ POT :{' '}
+        {t('pot.label')}{' '}
         <span
           key={pot}
           style={{ display: 'inline-block', animation: 'numUpdate 0.4s ease-out' }}

--- a/frontend/src/i18n/I18nContext.tsx
+++ b/frontend/src/i18n/I18nContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import locales from './locales';
+import type { Locale } from './locales';
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (l: Locale) => void;
+  t: (key: string) => string;
+}
+
+const STORAGE_KEY = 'cyber_holdem_locale';
+
+function getInitialLocale(): Locale {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'en' || saved === 'zh') return saved;
+  } catch { /* SSR / private mode */ }
+  return 'en';
+}
+
+const I18nContext = createContext<I18nContextValue>({
+  locale: 'en',
+  setLocale: () => {},
+  t: (key: string) => key,
+});
+
+interface I18nProviderProps {
+  children: React.ReactNode;
+}
+
+export const I18nProvider: React.FC<I18nProviderProps> = ({ children }) => {
+  const [locale, setLocaleState] = useState<Locale>(getInitialLocale);
+
+  const setLocale = useCallback((l: Locale) => {
+    setLocaleState(l);
+    try { localStorage.setItem(STORAGE_KEY, l); } catch { /* ignore */ }
+  }, []);
+
+  const t = useCallback((key: string): string => {
+    return locales[locale][key] ?? locales.en[key] ?? key;
+  }, [locale]);
+
+  const value = useMemo(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
+
+  return (
+    <I18nContext.Provider value={value}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+/** Hook to access translations and locale switching. */
+export function useT(): I18nContextValue {
+  return useContext(I18nContext);
+}
+
+export type { Locale };

--- a/frontend/src/i18n/locales.ts
+++ b/frontend/src/i18n/locales.ts
@@ -1,0 +1,135 @@
+export type Locale = 'en' | 'zh';
+
+const locales: Record<Locale, Record<string, string>> = {
+  en: {
+    // App / Header
+    'app.title': "CYBER HOLD'EM",
+    'app.subtitle': '1 HUMAN VS 5 AI BOTS',
+    'app.start': '▶ START GAME',
+    'app.nextHand': '▶ NEXT HAND',
+    'app.newGame': '▶ NEW GAME',
+    'app.continue': '▶ CONTINUE',
+    'app.menu': '⏚ MENU',
+    'header.blind': 'BLIND',
+    'header.street': 'STREET',
+    'header.pot': 'POT',
+    'header.hand': 'HAND',
+    'header.connected': '● CONNECTED',
+    'header.disconnected': '● DISCONNECTED',
+
+    // Actions
+    'action.fold': 'FOLD',
+    'action.check': 'CHECK',
+    'action.call': 'CALL',
+    'action.raise': 'RAISE',
+    'action.allin': 'ALL IN',
+    'action.askAi': '◈ ASK AI',
+    'action.thinking': '◈ THINKING...',
+
+    // Player status
+    'status.fold': 'FOLD',
+    'status.allin': 'ALL IN',
+    'status.thinking': 'THINKING ▌',
+    'status.bet': 'BET',
+    'status.waiting': 'WAITING',
+
+    // Bet controls
+    'bet.halfPot': '½ POT',
+    'bet.pot': 'POT',
+    'bet.2xbb': '2×BB',
+    'bet.step': 'STEP',
+    'bet.odds': 'ODDS',
+
+    // Dealer
+    'dealer.label': '◈ DEALER',
+    'dealer.dealing': '◈ DEALING...',
+    'dealer.showdown': '◈ SHOWDOWN ◈',
+
+    // Pot
+    'pot.label': '◈ POT :',
+
+    // Game over
+    'gameover.title': 'GAME OVER',
+    'gameover.eliminated': "You've been eliminated.",
+
+    // HoleCards / HumanPanel
+    'human.yourHand': 'YOUR HAND',
+    'human.yourTurn': 'YOUR TURN',
+    'human.you': 'YOU',
+    'human.inPos': 'IN POS',
+    'human.oop': 'OOP',
+
+    // AI Coach
+    'coach.title': '◈ AI COACH',
+    'coach.thinking': '◈ AI THINKING...',
+    'coach.recommend': 'Recommend:',
+    'coach.empty': 'Click ◈ ASK AI to get advice',
+
+    // Showdown
+    'showdown.label': '◈ SHOWDOWN ◈',
+
+    // Language
+    'lang.select': 'SELECT LANGUAGE',
+  },
+  zh: {
+    'app.title': '赛博德扑',
+    'app.subtitle': '1 位玩家 VS 5 个 AI',
+    'app.start': '▶ 开始游戏',
+    'app.nextHand': '▶ 下一手',
+    'app.newGame': '▶ 新游戏',
+    'app.continue': '▶ 继续',
+    'app.menu': '⏚ 菜单',
+    'header.blind': '盲注',
+    'header.street': '阶段',
+    'header.pot': '底池',
+    'header.hand': '手数',
+    'header.connected': '● 已连接',
+    'header.disconnected': '● 未连接',
+
+    'action.fold': '弃牌',
+    'action.check': '过牌',
+    'action.call': '跟注',
+    'action.raise': '加注',
+    'action.allin': '全下',
+    'action.askAi': '◈ AI分析',
+    'action.thinking': '◈ 分析中...',
+
+    'status.fold': '弃牌',
+    'status.allin': '全下',
+    'status.thinking': '思考中 ▌',
+    'status.bet': '下注',
+    'status.waiting': '等待中',
+
+    'bet.halfPot': '½ 底池',
+    'bet.pot': '底池',
+    'bet.2xbb': '2×大盲',
+    'bet.step': '步长',
+    'bet.odds': '赔率',
+
+    'dealer.label': '◈ 荷官',
+    'dealer.dealing': '◈ 发牌中...',
+    'dealer.showdown': '◈ 摊牌 ◈',
+
+    'pot.label': '◈ 底池 :',
+
+    'gameover.title': '游戏结束',
+    'gameover.eliminated': '你的筹码已经输光了。',
+
+    'human.yourHand': '你的手牌',
+    'human.yourTurn': '你的回合',
+    'human.you': '你',
+    'human.inPos': '有位置',
+    'human.oop': '无位置',
+
+    'coach.title': '◈ AI 教练',
+    'coach.thinking': '◈ AI 分析中...',
+    'coach.recommend': '推荐：',
+    'coach.empty': '点击 ◈ AI分析 获取建议',
+
+    'showdown.label': '◈ 摊牌 ◈',
+
+    'lang.select': '选择语言',
+  },
+};
+
+export default locales;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { I18nProvider } from './i18n/I18nContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <I18nProvider>
+      <App />
+    </I18nProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
- Fix position badge (BTN/SB/BB) clipping by moving it outside clipPath div
- Add game-over detection: emit game_over event when human chips reach 0
- Add reset_game/connect/set_locale socket handlers for quit/restart/reconnect
- Add full Chinese/English i18n: ~50 UI strings, language selector on start screen and in-game menu, localStorage persistence
- Add Chinese bot chat lines for all 5 personalities (shark/rock/maniac/ station/tag) with locale-aware _chat() function
- Add game-over overlay with NEW GAME button
- Add in-game MENU button with language switch, new game, continue options
- Replace hardcoded strings with t() calls across all 10 component files