### PR TITLE
feat: shrink AI player boxes, fix overlap, add per-personality think …

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -55,6 +55,16 @@ BOT_PROFILES: list[dict[str, str]] = [
     {'id': 'bot_5', 'name': 'CIPHER',  'personality': 'tag'},
 ]
 
+# ─── Per-bot thinking delay (seconds) tuned to personality ────────────────────
+BOT_THINK_TIME: dict[str, tuple[float, float]] = {
+    'bot_1': (1.2, 3.0),   # NEON    / shark   — balanced, calculated
+    'bot_2': (2.0, 4.5),   # GRANITE / rock    — slow, deliberate
+    'bot_3': (0.8, 2.0),   # BLAZE   / maniac  — fast, impulsive
+    'bot_4': (1.5, 4.0),   # GLACIER / station — indecisive
+    'bot_5': (1.2, 3.5),   # CIPHER  / tag     — moderate
+}
+_DEFAULT_THINK_TIME: tuple[float, float] = (1.0, 2.5)
+
 # ─── Global state ─────────────────────────────────────────────────────────────
 engine = PokerEngine()
 # Per-bot strategy dict (for rule-based mode, each bot has its own personality)
@@ -146,7 +156,8 @@ async def check_ai_turn() -> None:
         if not (current_p.id.startswith('bot_') and current_p.is_active and not current_p.is_all_in):
             break
 
-        await asyncio.sleep(random.uniform(0.5, 1.2))
+        think_lo, think_hi = BOT_THINK_TIME.get(current_p.id, _DEFAULT_THINK_TIME)
+        await asyncio.sleep(random.uniform(think_lo, think_hi))
         state_for_bot = engine.get_public_game_state(current_p.id)
 
         strategy = _get_strategy(current_p.id)

--- a/frontend/src/components/player/PlayerBox.tsx
+++ b/frontend/src/components/player/PlayerBox.tsx
@@ -40,8 +40,8 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   const boxStyle: React.CSSProperties = {
     background: 'rgba(10, 9, 0, 0.88)',
     border: '2px solid var(--brown)',
-    padding: '20px 28px',
-    width: 400,
+    padding: '10px 14px',
+    width: 260,
     clipPath: 'var(--clip-sm)',
     opacity: isFolded ? 0.3 : 1,
     flexShrink: 0,
@@ -72,11 +72,11 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
       {/* Amount label below the stack */}
       <div style={{
         fontFamily: 'var(--font-ui)',
-        fontSize: 14,
+        fontSize: 12,
         color: 'var(--gold)',
         background: '#1a0e00',
         border: '1px solid var(--gold-d)',
-        padding: '4px 10px',
+        padding: '2px 6px',
         whiteSpace: 'nowrap',
       }}>
         <span
@@ -106,8 +106,8 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
             right: 5,
             background: 'var(--gold)',
             color: '#000',
-            fontSize: 14,
-            padding: '4px 10px',
+            fontSize: 11,
+            padding: '2px 6px',
             fontFamily: 'var(--font-ui)',
             lineHeight: 1.4,
             zIndex: 2,
@@ -121,9 +121,9 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
           {/* Bot name */}
           <div style={{
             fontFamily: 'var(--font-ui)',
-            fontSize: 22,
+            fontSize: 14,
             color: 'var(--gold)',
-            marginBottom: 6,
+            marginBottom: 4,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -133,9 +133,9 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
           {/* Chips — key replays numUpdate animation when chips change */}
           <div style={{
-            fontSize: 16,
+            fontSize: 11,
             color: 'var(--gold-l)',
-            marginBottom: 5,
+            marginBottom: 4,
             fontFamily: 'var(--font-label)',
           }}>
             <span
@@ -148,7 +148,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
           {/* Status */}
           <div style={{
-            fontSize: 16,
+            fontSize: 10,
             color: status.color,
             fontFamily: 'var(--font-label)',
           }}>
@@ -156,7 +156,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
           </div>
 
           {/* Cards (face-down or face-up at showdown) */}
-          <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+          <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
             {showCards ? (
               <>
                 <Card

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -202,12 +202,12 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
             />
           )}
 
-          {/* Human player info box (bottom right) */}
+          {/* Human player info box (bottom center-right, beside hole cards) */}
           {humanPlayer && (
             <div style={{
               position: 'absolute',
               bottom: 20,
-              right: 10,
+              left: 'calc(50% + 90px)',
             }}>
               <HumanPanel
                 player={humanPlayer}


### PR DESCRIPTION
…time

- PlayerBox: reduce width 400→260px, padding 20/28→10/14px, scale down all font sizes (name 22→14, chips 16→11, status 16→10) and card gap
- PokerTable: move HumanPanel from bottom-right to bottom center-right (left: calc(50%+90px)) so it no longer conflicts with right-column bots
- backend/main.py: add BOT_THINK_TIME dict giving each AI personality its own thinking delay (rock 2–4.5s, maniac 0.8–2s, others 1.2–3.5s) so "THINKING" badge stays visible and gameplay feels more authentic

https://claude.ai/code/session_01Ct4SScRTwXDefKqLJLDj19