### PR TITLE
fix: install curl in backend Docker image for healthcheck

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.9-slim
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
python:3.9-slim does not include curl; the P3-4 healthcheck change (curl -f instead of python urllib) requires curl to be present in the container image.

https://claude.ai/code/session_01Ct4SScRTwXDefKqLJLDj19