### PR TITLE
Mobile landscape UI, GTO personality system, and showdown improvements

### DIFF
--- a/backend/src/ai/gto_strategy.py
+++ b/backend/src/ai/gto_strategy.py
@@ -1,8 +1,10 @@
 """
-Pseudo-GTO bot strategy for Texas Hold'em.
+Pseudo-GTO bot strategy for Texas Hold'em, with per-personality modifiers.
 
 Pre-flop  : position-based range tables with mixed-frequency decisions.
+            Uses raise_count to correctly distinguish "open raise" from "facing a raise".
 Post-flop : Monte Carlo equity + board texture → geometric bet sizing + GTO bluff freq.
+            Personality shifts thresholds so each bot has a distinct character.
 
 No external poker library required.
 """
@@ -10,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import random
+from dataclasses import dataclass
 from typing import Any, List, Optional
 
 from ..engine import Card, Rank, Suit
@@ -18,10 +21,11 @@ from .strategy import BotStrategy
 from .preflop_ranges import get_hand_combo, get_position, preflop_open_freq, preflop_call_freq
 from .equity import estimate_equity
 from .board_texture import analyze_board, BoardTexture
+from .rule_based import PERSONALITIES, Personality, _chat as _personality_chat
 
 logger = logging.getLogger(__name__)
 
-# ─── Constants ────────────────────────────────────────────────────────────────
+# ─── GTO Constants ────────────────────────────────────────────────────────────
 
 # Pre-flop: BB squeeze
 _BB_SQUEEZE_OPEN_THRESH: float = 0.70  # open_f must exceed this for BB to consider squeeze
@@ -39,13 +43,13 @@ _WETNESS_THRESHOLD: float = 0.50       # wetness ≥ this → use larger sizing
 _WET_BET_FRAC: float = 0.66            # 2/3 pot on wet boards
 _DRY_BET_FRAC: float = 0.33            # 1/3 pot on dry boards
 
-# Post-flop: equity thresholds for value / bluff decisions
+# Post-flop: base equity thresholds (before personality offset)
 _WET_VALUE_THRESH: float = 0.70        # equity needed to value-bet on wet boards
 _DRY_VALUE_THRESH: float = 0.65        # equity needed to value-bet on dry boards
 _BLUFF_EQUITY_THRESH: float = 0.30     # equity below which bot may bluff (when checking)
 _SEMI_BLUFF_EQUITY_THRESH: float = 0.20  # equity below which semi-bluff raise is allowed
 
-# Post-flop: equity margins over pot odds
+# Post-flop: base equity margins over pot odds
 _VALUE_RAISE_MARGIN: float = 0.10      # equity must exceed pot_odds by this to value-raise
 _CALL_MARGIN: float = 0.08             # equity must exceed pot_odds by this to call
 
@@ -53,30 +57,36 @@ _CALL_MARGIN: float = 0.08             # equity must exceed pot_odds by this to 
 _MARGINAL_CALL_PROB: float = 0.35      # frequency of marginal calls when equity barely > pot_odds
 
 
-# ─── Chat message pools ───────────────────────────────────────────────────────
+# ─── Personality modifier system ──────────────────────────────────────────────
 
-_CHAT: dict[str, List[str]] = {
-    'fold':  [
-        'Not my spot.', 'I fold.', 'Bad equity.', 'Range disadvantage.',
-        'Folding this one.', 'Not profitable here.',
-    ],
-    'check': [
-        'Checking.', 'I check.', 'Pot control.', 'Taking a free card.',
-        'Check.', 'Checking my option.',
-    ],
-    'call':  [
-        'Call.', 'I call.', "I've got the odds.", 'Calling.',
-        'Price is right.', 'Pot odds check out.',
-    ],
-    'raise': [
-        'Raise.', 'I raise.', "I'm ahead here.", 'Value bet.',
-        'Geometric sizing.', 'Building the pot.', 'Let\'s play.',
-    ],
+@dataclass(frozen=True)
+class _PersonalityMod:
+    """Offsets/multipliers applied to GTO base thresholds per personality."""
+    open_freq_mult: float      # multiply preflop open/call freq  (>1 = wider range)
+    value_thresh_offset: float # add to value threshold           (negative = bets more aggressively)
+    call_margin_offset: float  # add to call margin               (negative = calls more / folds less)
+    bluff_freq_mult: float     # multiply GTO bluff frequency     (>1 = bluffs more)
+
+
+_PERSONALITY_MODS: dict[str, _PersonalityMod] = {
+    # shark: balanced GTO+, slightly elevated bluff frequency
+    'shark':   _PersonalityMod(open_freq_mult=1.00, value_thresh_offset=0.00,
+                               call_margin_offset=0.00, bluff_freq_mult=1.20),
+    # rock: only opens top 70% of GTO range, bets with high equity only, almost never bluffs
+    'rock':    _PersonalityMod(open_freq_mult=0.70, value_thresh_offset=0.06,
+                               call_margin_offset=0.08, bluff_freq_mult=0.20),
+    # maniac: 140% open range, value-bets with 12% less equity, hyper-aggressive bluffing
+    'maniac':  _PersonalityMod(open_freq_mult=1.40, value_thresh_offset=-0.12,
+                               call_margin_offset=-0.12, bluff_freq_mult=2.50),
+    # station: normal range, very rarely bets, calls with 18% worse equity than GTO
+    'station': _PersonalityMod(open_freq_mult=1.05, value_thresh_offset=0.02,
+                               call_margin_offset=-0.18, bluff_freq_mult=0.40),
+    # tag: tight-aggressive GTO-clone, slightly fewer bluffs
+    'tag':     _PersonalityMod(open_freq_mult=1.00, value_thresh_offset=0.00,
+                               call_margin_offset=0.00, bluff_freq_mult=0.80),
 }
 
-
-def _chat(action: str) -> str:
-    return random.choice(_CHAT.get(action, ['...']))
+_DEFAULT_MOD = _PERSONALITY_MODS['shark']
 
 
 # ─── Card reconstruction from game-state dicts ───────────────────────────────
@@ -108,17 +118,25 @@ def _parse_hand(hand_raw: List[Optional[dict[str, Any]]]) -> List[Card]:
 
 class GTOBotStrategy(BotStrategy):
     """
-    Pseudo-GTO bot strategy.
+    Pseudo-GTO bot strategy with personality-adjusted thresholds.
 
     Pre-flop decisions use position-based RFI and call frequency tables.
+    raise_count from game state correctly distinguishes an open-raise opportunity
+    from facing an actual raise (fixing the previous can_check-only bug).
+
     Post-flop decisions use Monte Carlo equity, board texture analysis,
-    and GTO-balanced bet sizing / bluff frequencies.
+    and GTO-balanced bet sizing / bluff frequencies, modulated by personality.
     """
 
     # Number of Monte Carlo simulations per decision
     N_SIM_POSTFLOP: int = 500
 
-    def decide(self, game_state: dict[str, Any], player_id: str) -> AIThought:
+    def __init__(self, personality: str = 'shark') -> None:
+        self._personality_name: str = personality
+        self._mods: _PersonalityMod = _PERSONALITY_MODS.get(personality, _DEFAULT_MOD)
+        self._p: Personality = PERSONALITIES.get(personality, PERSONALITIES['shark'])
+
+    def decide(self, game_state: dict[str, Any], player_id: str, locale: str = 'en') -> AIThought:
         """Main entry: dispatch to pre- or post-flop logic."""
         street: str = game_state.get('state', 'PREFLOP')
         players: List[dict[str, Any]] = game_state.get('players', [])
@@ -126,12 +144,13 @@ class GTOBotStrategy(BotStrategy):
         me = next((p for p in players if p['id'] == player_id), None)
         if me is None:
             logger.warning('GTOBotStrategy: player %s not found in state', player_id)
-            return AIThought(action='fold', amount=0, thought='player not found', chat_message='Fold.')
+            return AIThought(action='fold', amount=0, thought='player not found',
+                             chat_message=_personality_chat(self._p, 'fold', locale))
 
         my_hand = _parse_hand(me.get('hand', []))
         if not my_hand:
-            # No visible hand (shouldn't happen for the bot itself)
-            return AIThought(action='fold', amount=0, thought='no hand', chat_message='Fold.')
+            return AIThought(action='fold', amount=0, thought='no hand',
+                             chat_message=_personality_chat(self._p, 'fold', locale))
 
         community_raw: List[dict[str, Any]] = game_state.get('community_cards', [])
         community = _parse_hand(community_raw)
@@ -142,12 +161,13 @@ class GTOBotStrategy(BotStrategy):
         pot: int = game_state.get('pot', 0)
         current_bet: int = game_state.get('current_bet', 0)
         min_raise: int = game_state.get('min_raise', 20)
+        raise_count: int = game_state.get('raise_count', 0)
         my_bet: int = me.get('current_bet', 0)
         my_chips: int = me.get('chips', 0)
         to_call: int = max(0, current_bet - my_bet)
         can_check: bool = to_call == 0
 
-        # Find dealer index
+        # Find dealer index for position calculation
         dealer_idx = next(
             (i for i, p in enumerate(players) if p.get('is_dealer')), 0
         )
@@ -163,6 +183,8 @@ class GTOBotStrategy(BotStrategy):
                 pot=pot,
                 min_raise=min_raise,
                 my_chips=my_chips,
+                raise_count=raise_count,
+                locale=locale,
             )
         else:
             return self._decide_postflop(
@@ -174,6 +196,7 @@ class GTOBotStrategy(BotStrategy):
                 pot=pot,
                 min_raise=min_raise,
                 my_chips=my_chips,
+                locale=locale,
             )
 
     # ── Pre-flop ──────────────────────────────────────────────────────────────
@@ -187,83 +210,85 @@ class GTOBotStrategy(BotStrategy):
         pot: int,
         min_raise: int,
         my_chips: int,
+        raise_count: int,
+        locale: str = 'en',
     ) -> AIThought:
         combo = get_hand_combo(my_hand[0], my_hand[1])
-        open_f = preflop_open_freq(combo, position)
-        call_f = preflop_call_freq(combo, position)
+        # Apply personality range multiplier (maniac opens wider, rock tighter)
+        open_f = min(1.0, preflop_open_freq(combo, position) * self._mods.open_freq_mult)
+        call_f = min(1.0, preflop_call_freq(combo, position) * self._mods.open_freq_mult)
 
-        # BB special case: no open-raise needed (already posted)
+        # ── CASE 1: BB with option to check (nobody has raised above the blind) ──
         if position == 'BB' and can_check:
-            # BB can squeeze with 3-bet hands or check
             if open_f > _BB_SQUEEZE_OPEN_THRESH and random.random() < _BB_SQUEEZE_PROB:
-                raise_amount = min(min_raise * 3, my_chips)
-                if raise_amount > 0:
-                    return AIThought(
-                        action='raise', amount=raise_amount,
-                        thought=f'BB squeeze: {combo} ({open_f:.0%} freq)',
-                        chat_message=_chat('raise'),
-                    )
+                raise_amount = max(min_raise, min(min_raise * 3, my_chips))
+                return AIThought(
+                    action='raise', amount=raise_amount,
+                    thought=f'BB squeeze: {combo} ({open_f:.0%} freq)',
+                    chat_message=_personality_chat(self._p, 'raise', locale),
+                )
             return AIThought(
                 action='check', amount=0,
                 thought=f'BB check: {combo}',
-                chat_message=_chat('check'),
+                chat_message=_personality_chat(self._p, 'check', locale),
             )
 
-        if can_check:
-            # Nobody has raised — decide whether to open-raise
+        # ── CASE 2: No raise yet — this is an open-raise opportunity ──────────
+        # (raise_count == 0 means nobody has voluntarily raised above the blind)
+        if raise_count == 0:
             if open_f > 0 and random.random() < open_f:
-                # Standard open: 2.5× BB (big_blind ≈ min_raise here)
-                raise_amount = min(min_raise * 2 + (min_raise // 2), my_chips)
-                raise_amount = max(raise_amount, min_raise)
+                # Standard open: 2.5× BB (min_raise ≈ BB when no raises have happened)
+                raise_amount = max(min_raise, min(min_raise * 2 + min_raise // 2, my_chips))
                 return AIThought(
                     action='raise', amount=raise_amount,
                     thought=f'Open raise: {combo} at {position} ({open_f:.0%})',
-                    chat_message=_chat('raise'),
+                    chat_message=_personality_chat(self._p, 'raise', locale),
                 )
-            return AIThought(
-                action='check', amount=0,
-                thought=f'Check behind: {combo} at {position}',
-                chat_message=_chat('check'),
-            )
-        else:
-            # There is a raise to face
-            if to_call >= my_chips:
-                # All-in or fold decision
-                if call_f > 0 and random.random() < call_f * _ALLIN_CALL_FREQ_MULT:
-                    return AIThought(
-                        action='call', amount=0,
-                        thought=f'All-in call: {combo}',
-                        chat_message=_chat('call'),
-                    )
-                return AIThought(
-                    action='fold', amount=0,
-                    thought=f'Fold to all-in: {combo}',
-                    chat_message=_chat('fold'),
-                )
-
-            # 3-bet opportunity: strong hands get aggressive
-            three_bet_f = max(0.0, open_f - _THREE_BET_OPEN_OFFSET)  # only widest openers 3-bet
-            if three_bet_f > 0 and random.random() < three_bet_f * _THREE_BET_FREQ_MULT:
-                raise_amount = min(to_call * 3, my_chips)
-                raise_amount = max(raise_amount, min_raise)
-                return AIThought(
-                    action='raise', amount=raise_amount,
-                    thought=f'3-bet: {combo} at {position} (3bet freq {three_bet_f:.0%})',
-                    chat_message=_chat('raise'),
-                )
-
-            if call_f > 0 and random.random() < call_f:
-                return AIThought(
-                    action='call', amount=0,
-                    thought=f'Call raise: {combo} at {position} ({call_f:.0%})',
-                    chat_message=_chat('call'),
-                )
-
+            # GTO preflop rarely limps; fold hands outside opening range
             return AIThought(
                 action='fold', amount=0,
-                thought=f'Fold pre-flop: {combo} at {position} (call_f={call_f:.0%})',
-                chat_message=_chat('fold'),
+                thought=f'Fold pre-flop (outside range): {combo} at {position}',
+                chat_message=_personality_chat(self._p, 'fold', locale),
             )
+
+        # ── CASE 3: Facing an actual raise (raise_count >= 1) ─────────────────
+        if to_call >= my_chips:
+            # All-in or fold decision
+            if call_f > 0 and random.random() < call_f * _ALLIN_CALL_FREQ_MULT:
+                return AIThought(
+                    action='call', amount=0,
+                    thought=f'All-in call: {combo}',
+                    chat_message=_personality_chat(self._p, 'call', locale),
+                )
+            return AIThought(
+                action='fold', amount=0,
+                thought=f'Fold to all-in: {combo}',
+                chat_message=_personality_chat(self._p, 'fold', locale),
+            )
+
+        # 3-bet opportunity: strong hands get aggressive
+        three_bet_f = max(0.0, open_f - _THREE_BET_OPEN_OFFSET)
+        if three_bet_f > 0 and random.random() < three_bet_f * _THREE_BET_FREQ_MULT:
+            raise_amount = max(min_raise, min(to_call * 3, my_chips))
+            return AIThought(
+                action='raise', amount=raise_amount,
+                thought=f'3-bet: {combo} at {position} (3bet_f={three_bet_f:.0%})',
+                chat_message=_personality_chat(self._p, 'raise', locale),
+            )
+
+        # Call with hands in calling range
+        if call_f > 0 and random.random() < call_f:
+            return AIThought(
+                action='call', amount=0,
+                thought=f'Call raise: {combo} at {position} ({call_f:.0%})',
+                chat_message=_personality_chat(self._p, 'call', locale),
+            )
+
+        return AIThought(
+            action='fold', amount=0,
+            thought=f'Fold pre-flop: {combo} at {position} (call_f={call_f:.0%})',
+            chat_message=_personality_chat(self._p, 'fold', locale),
+        )
 
     # ── Post-flop ─────────────────────────────────────────────────────────────
 
@@ -277,65 +302,75 @@ class GTOBotStrategy(BotStrategy):
         pot: int,
         min_raise: int,
         my_chips: int,
+        locale: str = 'en',
     ) -> AIThought:
         # Monte Carlo equity estimation
         num_opp = max(1, active_opponents)
         equity = estimate_equity(my_hand, community, num_opp, n_sim=self.N_SIM_POSTFLOP)
 
-        # Board texture
+        # Board texture drives base bet sizing and value threshold
         texture: BoardTexture = analyze_board(community)
 
-        # Pot odds (how much equity we need to profitably call)
-        if to_call > 0:
-            pot_odds = to_call / (pot + to_call + 1e-6)
-        else:
-            pot_odds = 0.0
+        # Pot odds (minimum equity needed to break even on a call)
+        pot_odds = to_call / (pot + to_call + 1e-6) if to_call > 0 else 0.0
 
-        # ── Bet sizing based on texture ──────────────────────────────────────
-        # Dry boards → smaller sizing; wet boards → larger sizing
+        # ── Board-texture base thresholds ────────────────────────────────────
         if texture.wetness >= _WETNESS_THRESHOLD:
-            bet_fraction = _WET_BET_FRAC    # 2/3 pot on wet boards
-            value_threshold = _WET_VALUE_THRESH
+            bet_fraction = _WET_BET_FRAC       # 2/3 pot on wet boards
+            base_value_thresh = _WET_VALUE_THRESH
         else:
-            bet_fraction = _DRY_BET_FRAC    # 1/3 pot on dry boards
-            value_threshold = _DRY_VALUE_THRESH
+            bet_fraction = _DRY_BET_FRAC       # 1/3 pot on dry boards
+            base_value_thresh = _DRY_VALUE_THRESH
 
+        # ── Apply personality modifiers ───────────────────────────────────────
+        value_threshold = base_value_thresh + self._mods.value_thresh_offset
+        call_margin = _CALL_MARGIN + self._mods.call_margin_offset
+        value_raise_margin = _VALUE_RAISE_MARGIN + self._mods.call_margin_offset
+
+        # Bet size: clamped to [min_raise, my_chips]
         bet_size = max(int(pot * bet_fraction), min_raise)
         bet_size = min(bet_size, my_chips)
 
-        # GTO bluff frequency: bet_size / (pot + 2 * bet_size)
-        bluff_freq = bet_size / (pot + 2 * bet_size + 1e-6)
+        # GTO bluff frequency with personality multiplier
+        raw_bluff_freq = bet_size / (pot + 2 * bet_size + 1e-6)
+        bluff_freq = min(1.0, raw_bluff_freq * self._mods.bluff_freq_mult)
 
         thought_base = (
-            f'equity={equity:.0%} pot_odds={pot_odds:.0%} '
-            f'wet={texture.wetness:.2f} bluff_f={bluff_freq:.0%}'
+            f'[{self._personality_name}] equity={equity:.0%} pot_odds={pot_odds:.0%} '
+            f'wet={texture.wetness:.2f} val_thresh={value_threshold:.2f} bluff_f={bluff_freq:.0%}'
+        )
+
+        logger.debug(
+            'GTOBot[%s]: %s equity=%.2f pot_odds=%.2f wet=%.2f val_thresh=%.2f',
+            self._personality_name, 'check' if can_check else f'face {to_call}',
+            equity, pot_odds, texture.wetness, value_threshold,
         )
 
         # ── Decision tree ────────────────────────────────────────────────────
         if can_check:
-            # No bet to face
+            # No bet to face — decide whether to bet or check
             if equity >= value_threshold:
                 # Value bet
                 return AIThought(
                     action='raise', amount=bet_size,
                     thought=f'Value bet: {thought_base}',
-                    chat_message=_chat('raise'),
+                    chat_message=_personality_chat(self._p, 'raise', locale),
                 )
             if equity < _BLUFF_EQUITY_THRESH and random.random() < bluff_freq:
-                # Bluff with balanced frequency
+                # Bluff with GTO-balanced frequency
                 return AIThought(
                     action='raise', amount=bet_size,
                     thought=f'Bluff: {thought_base}',
-                    chat_message=_chat('raise'),
+                    chat_message=_personality_chat(self._p, 'raise', locale),
                 )
             return AIThought(
                 action='check', amount=0,
                 thought=f'Check: {thought_base}',
-                chat_message=_chat('check'),
+                chat_message=_personality_chat(self._p, 'check', locale),
             )
         else:
             # Facing a bet
-            if equity >= value_threshold and equity > pot_odds + _VALUE_RAISE_MARGIN:
+            if equity >= value_threshold and equity > pot_odds + value_raise_margin:
                 # Re-raise for value
                 re_raise = min(int(pot * bet_fraction * 1.5), my_chips)
                 re_raise = max(re_raise, min_raise)
@@ -343,44 +378,44 @@ class GTOBotStrategy(BotStrategy):
                     # Not enough chips to raise — just call
                     return AIThought(
                         action='call', amount=0,
-                        thought=f'Call (value): {thought_base}',
-                        chat_message=_chat('call'),
+                        thought=f'Call (value, no raise room): {thought_base}',
+                        chat_message=_personality_chat(self._p, 'call', locale),
                     )
                 return AIThought(
                     action='raise', amount=re_raise,
                     thought=f'Value raise: {thought_base}',
-                    chat_message=_chat('raise'),
+                    chat_message=_personality_chat(self._p, 'raise', locale),
                 )
 
-            if equity > pot_odds + _CALL_MARGIN:
-                # Profitable call by equity
+            if equity > pot_odds + call_margin:
+                # Profitable call by equity margin
                 return AIThought(
                     action='call', amount=0,
                     thought=f'Call (odds): {thought_base}',
-                    chat_message=_chat('call'),
+                    chat_message=_personality_chat(self._p, 'call', locale),
                 )
 
             if equity > pot_odds and random.random() < _MARGINAL_CALL_PROB:
-                # Marginal call — mixed strategy
+                # Marginal call — mixed strategy to stay unexploitable
                 return AIThought(
                     action='call', amount=0,
                     thought=f'Marginal call: {thought_base}',
-                    chat_message=_chat('call'),
+                    chat_message=_personality_chat(self._p, 'call', locale),
                 )
 
             if equity < _SEMI_BLUFF_EQUITY_THRESH and random.random() < bluff_freq * 0.5:
-                # Bluff raise even when facing a bet (semi-bluff territory)
+                # Semi-bluff raise facing a bet
                 bluff_raise = min(int(pot * _WET_BET_FRAC), my_chips)
                 bluff_raise = max(bluff_raise, min_raise)
                 if bluff_raise > to_call and my_chips > to_call:
                     return AIThought(
                         action='raise', amount=bluff_raise,
                         thought=f'Semi-bluff raise: {thought_base}',
-                        chat_message=_chat('raise'),
+                        chat_message=_personality_chat(self._p, 'raise', locale),
                     )
 
             return AIThought(
                 action='fold', amount=0,
                 thought=f'Fold: {thought_base}',
-                chat_message=_chat('fold'),
+                chat_message=_personality_chat(self._p, 'fold', locale),
             )

--- a/backend/src/engine.py
+++ b/backend/src/engine.py
@@ -71,6 +71,24 @@ class HandEvaluator:
         return best_rank, best_tiebreakers
 
     @staticmethod
+    def best_five(cards: List[Card]) -> List[Card]:
+        """Return the 5 cards that form the best hand from the given cards."""
+        import itertools
+        best_rank = HandRank.HIGH_CARD
+        best_tiebreakers: List[int] = []
+        best_combo: List[Card] = list(cards[:5])
+        for combo in itertools.combinations(cards, 5):
+            combo_list = sorted(list(combo), key=lambda c: c.rank.value, reverse=True)
+            rank, tiebreakers = HandEvaluator._evaluate_five(combo_list)
+            if rank.value > best_rank.value or (
+                rank.value == best_rank.value and tiebreakers > best_tiebreakers
+            ):
+                best_rank = rank
+                best_tiebreakers = tiebreakers
+                best_combo = combo_list
+        return best_combo
+
+    @staticmethod
     def _evaluate_five(cards: List[Card]) -> Tuple[HandRank, List[int]]:
         ranks = [c.rank.value for c in cards]
         suits = [c.suit for c in cards]
@@ -168,6 +186,7 @@ class PokerEngine:
         self.state = GameState.PREFLOP
         self.winners = []
         self.winning_hand_rank = ""
+        self.winning_cards: List[Card] = []
 
         for p in self.players:
             p.hand = []
@@ -331,6 +350,7 @@ class PokerEngine:
         self.state = GameState.SHOWDOWN
         self.winners = []
         self.winning_hand_rank = ""
+        self.winning_cards = []
 
         if winner_by_fold:
             winner_by_fold.chips += self.pot
@@ -360,6 +380,7 @@ class PokerEngine:
             
             self.winners = [w.id for w in winners_list]
             self.winning_hand_rank = best[1].name.replace("_", " ").title()
+            self.winning_cards = HandEvaluator.best_five(best[0].hand + self.community_cards)
 
         self.state = GameState.FINISHED
 
@@ -377,7 +398,8 @@ class PokerEngine:
             "max_raises_per_street": self.max_raises_per_street,
             "can_raise": self.raise_count < self.max_raises_per_street,
             "winners": getattr(self, "winners", []),
-            "winning_hand": getattr(self, "winning_hand_rank", "")
+            "winning_hand": getattr(self, "winning_hand_rank", ""),
+            "winning_cards": [c.to_dict() for c in getattr(self, "winning_cards", [])]
         }
 
         # Reveal hands at a real showdown: multiple players went to showdown (not fold-out)

--- a/backend/src/engine.py
+++ b/backend/src/engine.py
@@ -153,9 +153,13 @@ class PokerEngine:
         self.players.append(Player(player_id, name, chips))
 
     def start_hand(self):
-        # Rotate dealer
+        # Rotate dealer, skipping eliminated players (chips == 0)
         self.dealer_idx = (self.dealer_idx + 1) % len(self.players)
-        
+        steps = 0
+        while self.players[self.dealer_idx].chips == 0 and steps < len(self.players):
+            self.dealer_idx = (self.dealer_idx + 1) % len(self.players)
+            steps += 1
+
         self.reset_deck()
         self.community_cards = []
         self.pot = 0
@@ -164,14 +168,14 @@ class PokerEngine:
         self.state = GameState.PREFLOP
         self.winners = []
         self.winning_hand_rank = ""
-        
+
         for p in self.players:
             p.hand = []
             p.is_active = True if p.chips > 0 else False
             p.current_bet = 0
             p.is_all_in = False
             p.has_acted = False
-        
+
         active_count = sum(1 for p in self.players if p.is_active)
         if active_count < 2:
             raise ValueError("Not enough players")
@@ -181,14 +185,25 @@ class PokerEngine:
                 if p.is_active:
                     p.hand.append(self.deck.pop())
 
+        # Find first ACTIVE player after dealer for SB (skip eliminated seats)
         sb_idx = (self.dealer_idx + 1) % len(self.players)
-        bb_idx = (self.dealer_idx + 2) % len(self.players)
-        
+        steps = 0
+        while not self.players[sb_idx].is_active and steps < len(self.players):
+            sb_idx = (sb_idx + 1) % len(self.players)
+            steps += 1
+
+        # Find first ACTIVE player after SB for BB (skip eliminated seats)
+        bb_idx = (sb_idx + 1) % len(self.players)
+        steps = 0
+        while not self.players[bb_idx].is_active and steps < len(self.players):
+            bb_idx = (bb_idx + 1) % len(self.players)
+            steps += 1
+
         self._place_bet_logic(self.players[sb_idx], self.small_blind)
         self._place_bet_logic(self.players[bb_idx], self.big_blind)
-        
-        self.current_player_idx = (self.dealer_idx + 3) % len(self.players)
-        # Skip all-in or inactive players
+
+        # First to act preflop: first active non-all-in player after BB
+        self.current_player_idx = (bb_idx + 1) % len(self.players)
         steps = 0
         while not (self.players[self.current_player_idx].is_active and not self.players[self.current_player_idx].is_all_in) and steps < len(self.players):
             self.current_player_idx = (self.current_player_idx + 1) % len(self.players)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -97,20 +97,21 @@ def _build_strategy(
         return LLMBotStrategy(client), AICoach(client)
     if engine_name == 'gto':
         return GTOBotStrategy(), GTOCoach()
-    # 'rule-based' (default): bots use heuristics, human still gets GTO hints
-    return RuleBasedStrategy(), GTOCoach()
+    # 'rule-based' (default): bots use GTO+personality strategy, human gets GTO coach hints
+    return GTOBotStrategy(), GTOCoach()
 
 
 def _rebuild_bot_strategies(engine_name: str, model: str) -> None:
     """Rebuild the per-bot strategy dict.
 
-    For rule-based: each bot gets its own RuleBasedStrategy with a unique personality.
-    For GTO/LLM: all bots share the same _strategy instance (no per-bot dict needed).
+    For rule-based and gto: each bot gets its own GTOBotStrategy with a unique personality,
+    combining GTO-optimal math with distinct character via personality modifiers.
+    For LLM: all bots share the same LLMBotStrategy instance (no per-bot dict needed).
     """
     global _bot_strategies
-    if engine_name == 'rule-based':
+    if engine_name in ('rule-based', 'gto'):
         _bot_strategies = {
-            prof['id']: RuleBasedStrategy(personality=prof['personality'])
+            prof['id']: GTOBotStrategy(personality=prof['personality'])
             for prof in BOT_PROFILES
         }
     else:
@@ -171,7 +172,7 @@ async def check_ai_turn() -> None:
             try:
                 if isinstance(strategy, LLMBotStrategy):
                     decision = await strategy.decide_async(state_for_bot, current_p.id)
-                elif isinstance(strategy, RuleBasedStrategy):
+                elif isinstance(strategy, (RuleBasedStrategy, GTOBotStrategy)):
                     decision = strategy.decide(state_for_bot, current_p.id, locale=_locale)
                 else:
                     decision = strategy.decide(state_for_bot, current_p.id)

--- a/backend/tests/test_scenarios.py
+++ b/backend/tests/test_scenarios.py
@@ -606,15 +606,15 @@ def test_scenario_12_player_elimination_across_hands():
     assert carol.chips == 1100  # 900 + pot(200)
     assert sum(p.chips for p in engine.players) == 2100
 
-    # ── Hand 2: dealer rotates to 1 (Bob, inactive) ────────────────────────
+    # ── Hand 2: dealer skips Bob (0 chips) and lands on Carol ──────────────
     engine.start_hand()
-    assert engine.dealer_idx == 1
+    assert engine.dealer_idx == 2  # dealer skipped Bob(idx=1, 0 chips) → Carol(idx=2)
 
     bob = engine.players[1]
     assert bob.is_active is False  # Bob has 0 chips → sits out
 
-    # 2 active players: Carol (SB) and Alice (BB)
-    # SB=(1+1)%3=2(Carol), BB=(1+2)%3=0(Alice)
+    # 2 active players: dealer=Carol(2), SB=Alice(0), BB wraps to Carol(2)
+    # (Bob at idx=1 is inactive so BB skips past him back to Carol)
     alice = engine.players[0]
     carol = engine.players[2]
 
@@ -628,12 +628,13 @@ def test_scenario_12_player_elimination_across_hands():
         Card(Rank.FOUR, Suit.CLUBS),
     ]
 
-    # First active non-all-in player after dealer(Bob,inactive) is Carol (SB)
-    _act(engine, "p3", "call")   # Carol (SB) calls
-    _act(engine, "p1", "check")  # Alice (BB) checks → FLOP
-    _act(engine, "p3", "check"); _act(engine, "p1", "check")  # flop
-    _act(engine, "p3", "check"); _act(engine, "p1", "check")  # turn
-    _act(engine, "p3", "check"); _act(engine, "p1", "check")  # river
+    # Preflop: first to act is Alice (SB, first active after BB=Carol)
+    _act(engine, "p1", "call")   # Alice (SB) calls (+10 to match BB=20)
+    _act(engine, "p3", "check")  # Carol (BB) checks her option → FLOP
+    # Postflop: SB(Alice) acts first (first active left of dealer Carol)
+    _act(engine, "p1", "check"); _act(engine, "p3", "check")  # flop
+    _act(engine, "p1", "check"); _act(engine, "p3", "check")  # turn
+    _act(engine, "p1", "check"); _act(engine, "p3", "check")  # river
 
     assert engine.state == GameState.FINISHED
     assert engine.winners == ["p1"]  # AK > 32

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ function App() {
     setLocale: setBackendLocale,
     errorMessage,
     handCount,
+    actionInFlight,
     isGameOver: isPlayerEliminated,
   } = useGameStore();
 
@@ -242,7 +243,7 @@ function App() {
               onAction={sendAction}
               onAskAI={requestAdvice}
               isRequestingAdvice={isRequestingAdvice}
-              disabled={!isHumanTurn}
+              disabled={!isHumanTurn || actionInFlight}
               showCoach={showCoach}
             />
 
@@ -270,6 +271,40 @@ function App() {
           </>
         )}
       </main>
+
+      {/* ─── Disconnect overlay — covers table when socket lost during gameplay ─── */}
+      {gameState && !isConnected && (
+        <div style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.75)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1800,
+          gap: 14,
+          pointerEvents: 'none',
+        }}>
+          <div style={{
+            fontFamily: 'var(--font-ui)',
+            fontSize: 20,
+            color: '#cc4444',
+            letterSpacing: 4,
+            animation: 'blink 1s steps(1) infinite',
+          }}>
+            DISCONNECTED
+          </div>
+          <div style={{
+            fontFamily: 'var(--font-label)',
+            fontSize: 8,
+            color: 'var(--gold-d)',
+            letterSpacing: 2,
+          }}>
+            RECONNECTING...
+          </div>
+        </div>
+      )}
 
       {/* ─── Error Toast ─── */}
       {errorMessage && <ToastNotification message={errorMessage} />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -439,6 +439,28 @@ function App() {
         </div>
       )}
 
+      {/* ─── Portrait Rotation Prompt (mobile only, CSS-driven) ─── */}
+      <div className="portrait-overlay">
+        <div style={{
+          fontFamily: 'var(--font-ui)',
+          fontSize: 20,
+          color: 'var(--gold)',
+          letterSpacing: 3,
+          marginBottom: 16,
+        }}>
+          ↺
+        </div>
+        <div style={{
+          fontFamily: 'var(--font-label)',
+          fontSize: 8,
+          color: 'var(--gold-d)',
+          letterSpacing: 2,
+          textAlign: 'center',
+        }}>
+          ROTATE TO LANDSCAPE
+        </div>
+      </div>
+
       {/* ─── AI Coach Modal (always rendered at root level) ─── */}
       {showCoach && (
         <div

--- a/frontend/src/components/card/Card.tsx
+++ b/frontend/src/components/card/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { rankToDisplay, suitToSymbol, isRedSuit } from '../../utils/cardDisplay';
 
 export type CardSize = 'lg' | 'md' | 'sm' | 'xs';
-export type CardGlow = 'gold' | 'red' | 'none';
+export type CardGlow = 'gold' | 'red' | 'win' | 'none';
 export type CardVariant = 'face-up' | 'face-down' | 'placeholder';
 
 interface CardProps {
@@ -76,6 +76,7 @@ function getBoxShadow(size: CardSize, glow: CardGlow, variant: CardVariant): str
   const base = SIZES[size].shadow;
   if (glow === 'gold') return `${base}, 0 0 18px rgba(200,160,64,0.55)`;
   if (glow === 'red')  return `${base}, 0 0 16px rgba(204,17,17,0.4)`;
+  if (glow === 'win')  return `${base}, 0 0 10px rgba(0, 220, 160, 0.45)`;
   return base;
 }
 
@@ -84,6 +85,7 @@ function getBorderColor(glow: CardGlow, variant: CardVariant): string {
   if (variant === 'placeholder') return 'var(--card-back-border)';
   if (glow === 'gold') return 'var(--gold)';
   if (glow === 'red')  return 'var(--red)';
+  if (glow === 'win')  return '#00dca0';
   return 'var(--card-border)';
 }
 

--- a/frontend/src/components/layout/ActionBar.tsx
+++ b/frontend/src/components/layout/ActionBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { GameState } from '../../types';
 import { useT } from '../../i18n/I18nContext';
+import { useIsMobile } from '../../hooks/useIsMobile';
 
 interface ActionBarProps {
   gameState: GameState;
@@ -32,8 +33,10 @@ const ActionBar: React.FC<ActionBarProps> = ({
   showCoach,
 }) => {
   const { t } = useT();
+  const isMobile = useIsMobile();
   const [raiseAmount, setRaiseAmount] = useState<string>('');
   const [stepIdx, setStepIdx] = useState(2); // default step = STEPS[2] = 10
+  const [showRaiseSheet, setShowRaiseSheet] = useState(false);
 
   const human = gameState.players[0];
   const toCall = Math.max(0, gameState.current_bet - (human?.current_bet ?? 0));
@@ -65,6 +68,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
     const clamped = clamp(amt, minRaise, maxRaise);
     onAction('raise', clamped);
     setRaiseAmount('');
+    setShowRaiseSheet(false);
   }
 
   // ─── Keyboard shortcuts ────────────────────────────────────────────────────
@@ -171,121 +175,238 @@ const ActionBar: React.FC<ActionBarProps> = ({
 
       </div>
 
-      {/* ══════ Row 2 — Raise controls (fixed height slot, hidden when !canRaise) ══════ */}
-      {/*
-        Always takes up the same vertical space via height + visibility.
-        This is the key fix: the table above is never pushed around by this row appearing/disappearing.
-      */}
-      <div style={{
-        display: 'flex',
-        gap: 8,
-        justifyContent: 'center',
-        alignItems: 'center',
-        height: 46,
-        visibility: canRaise ? 'visible' : 'hidden',
-        flexWrap: 'nowrap',   // never wrap — width clips instead
-        overflow: 'hidden',
-      }}>
-
-        {/* Quick-bet buttons */}
-        <button className="abtn" style={smBtn} disabled={disabled}
-          onClick={() => setQuickBet(Math.round(gameState.pot / 2))}>
-          {t('bet.halfPot')}
-        </button>
-        <button className="abtn" style={smBtn} disabled={disabled}
-          onClick={() => setQuickBet(gameState.pot)}>
-          {t('bet.pot')}
-        </button>
-        <button className="abtn" style={smBtn} disabled={disabled}
-          onClick={() => setQuickBet(40)}>
-          {t('bet.2xbb')}
-        </button>
-
-        {/* Decrement */}
-        <button className="abtn" style={{ fontSize: 14, padding: '4px 10px', lineHeight: 1 }}
-          disabled={disabled} onClick={() => adjustAmount(-step)}>
-          ▼
-        </button>
-
-        {/* Amount input */}
-        <div style={{ position: 'relative' }}>
-          <input
-            className="raise-inp"
-            type="number"
-            min={minRaise}
-            max={maxRaise}
-            placeholder={`$${minRaise}`}
-            value={raiseAmount}
-            onChange={e => setRaiseAmount(e.target.value)}
+      {/* ══════ Row 2 — Raise controls ══════ */}
+      {isMobile ? (
+        /* Mobile: just RAISE (opens sheet) + ALL IN, same fixed-height slot */
+        <div style={{
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: 46,
+          visibility: canRaise ? 'visible' : 'hidden',
+        }}>
+          <button
+            className="abtn abtn-raise"
+            style={{ height: 46 }}
             disabled={disabled}
-            onKeyDown={e => e.key === 'Enter' && handleRaise()}
-            style={{
-              width: 90,
-              padding: '10px 10px',
-              borderColor: isOverMax ? '#ff4444' : undefined,
-              outline: isOverMax ? '1px solid #ff4444' : undefined,
-            }}
-          />
-          {isOverMax && (
-            <div style={{
-              position: 'absolute',
-              top: '100%',
-              left: 0,
-              fontSize: 7,
-              color: '#ff4444',
-              fontFamily: 'var(--font-label)',
-              whiteSpace: 'nowrap',
-              marginTop: 2,
-            }}>
-              Max ${maxRaise}
+            onClick={() => setShowRaiseSheet(true)}
+          >
+            {t('action.raise')} ▲
+          </button>
+          <button
+            className="abtn"
+            disabled={disabled}
+            onClick={() => onAction('allin', 0)}
+            style={{ height: 46, borderColor: '#aa2222', color: '#ff4444', fontSize: 7, padding: '4px 14px', lineHeight: 1.5 }}
+          >
+            {t('action.allin')}<br />${human?.chips}
+          </button>
+        </div>
+      ) : (
+        /* Desktop: full raise controls row (fixed height slot, hidden when !canRaise) */
+        <div style={{
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: 46,
+          visibility: canRaise ? 'visible' : 'hidden',
+          flexWrap: 'nowrap',
+          overflow: 'hidden',
+        }}>
+          <button className="abtn" style={smBtn} disabled={disabled}
+            onClick={() => setQuickBet(Math.round(gameState.pot / 2))}>
+            {t('bet.halfPot')}
+          </button>
+          <button className="abtn" style={smBtn} disabled={disabled}
+            onClick={() => setQuickBet(gameState.pot)}>
+            {t('bet.pot')}
+          </button>
+          <button className="abtn" style={smBtn} disabled={disabled}
+            onClick={() => setQuickBet(40)}>
+            {t('bet.2xbb')}
+          </button>
+          <button className="abtn" style={{ fontSize: 14, padding: '4px 10px', lineHeight: 1 }}
+            disabled={disabled} onClick={() => adjustAmount(-step)}>
+            ▼
+          </button>
+          <div style={{ position: 'relative' }}>
+            <input
+              className="raise-inp"
+              type="number"
+              min={minRaise}
+              max={maxRaise}
+              placeholder={`$${minRaise}`}
+              value={raiseAmount}
+              onChange={e => setRaiseAmount(e.target.value)}
+              disabled={disabled}
+              onKeyDown={e => e.key === 'Enter' && handleRaise()}
+              style={{
+                width: 90,
+                padding: '10px 10px',
+                borderColor: isOverMax ? '#ff4444' : undefined,
+                outline: isOverMax ? '1px solid #ff4444' : undefined,
+              }}
+            />
+            {isOverMax && (
+              <div style={{
+                position: 'absolute',
+                top: '100%',
+                left: 0,
+                fontSize: 7,
+                color: '#ff4444',
+                fontFamily: 'var(--font-label)',
+                whiteSpace: 'nowrap',
+                marginTop: 2,
+              }}>
+                Max ${maxRaise}
+              </div>
+            )}
+          </div>
+          <button className="abtn" style={{ fontSize: 14, padding: '4px 10px', lineHeight: 1 }}
+            disabled={disabled} onClick={() => adjustAmount(step)}>
+            ▲
+          </button>
+          <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
+            onClick={() => setStepIdx(i => (i - 1 + STEPS.length) % STEPS.length)}>
+            ◀
+          </button>
+          <div style={{ fontSize: 7, color: 'var(--gold-d)', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', letterSpacing: 1 }}>
+            {t('bet.step')} {step}
+          </div>
+          <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
+            onClick={() => setStepIdx(i => (i + 1) % STEPS.length)}>
+            ▶
+          </button>
+          <div style={{ fontSize: 7, color: 'var(--gold-d)', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', letterSpacing: 1 }}>
+            {minRaise}~{maxRaise}
+          </div>
+          <button
+            className="abtn abtn-raise"
+            disabled={disabled || raiseAmount === ''}
+            onClick={handleRaise}
+          >
+            {t('action.raise')} ▲<Hint k="R" />
+          </button>
+          <button
+            className="abtn"
+            disabled={disabled}
+            onClick={() => onAction('allin', 0)}
+            style={{ borderColor: '#aa2222', color: '#ff4444', fontSize: 7, padding: '4px 10px', lineHeight: 1.5 }}
+          >
+            {t('action.allin')}<br />${human?.chips}<Hint k="A" />
+          </button>
+        </div>
+      )}
+
+      {/* ══════ Mobile Raise Bottom Sheet ══════ */}
+      {isMobile && showRaiseSheet && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            background: 'var(--surface)',
+            border: '3px solid var(--gold)',
+            borderBottom: 'none',
+            padding: '12px 12px max(12px, env(safe-area-inset-bottom))',
+            zIndex: 400,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          {/* Sheet header */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ fontSize: 8, color: 'var(--gold)', fontFamily: 'var(--font-label)', letterSpacing: 2 }}>
+              {t('action.raise')} — {minRaise}~{maxRaise}
             </div>
-          )}
+            <button
+              style={{ background: 'none', border: '1px solid var(--gold-d)', color: 'var(--gold-d)', fontSize: 10, padding: '2px 8px', cursor: 'pointer', fontFamily: 'var(--font-label)' }}
+              onClick={() => setShowRaiseSheet(false)}
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Quick-bet row */}
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+            <button className="abtn" style={smBtn} disabled={disabled}
+              onClick={() => setQuickBet(Math.round(gameState.pot / 2))}>
+              {t('bet.halfPot')}
+            </button>
+            <button className="abtn" style={smBtn} disabled={disabled}
+              onClick={() => setQuickBet(gameState.pot)}>
+              {t('bet.pot')}
+            </button>
+            <button className="abtn" style={smBtn} disabled={disabled}
+              onClick={() => setQuickBet(40)}>
+              {t('bet.2xbb')}
+            </button>
+          </div>
+
+          {/* Amount input row */}
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center', alignItems: 'center' }}>
+            <button className="abtn" style={{ fontSize: 14, padding: '4px 12px', lineHeight: 1 }}
+              disabled={disabled} onClick={() => adjustAmount(-step)}>
+              ▼
+            </button>
+            <div style={{ position: 'relative' }}>
+              <input
+                className="raise-inp"
+                type="number"
+                min={minRaise}
+                max={maxRaise}
+                placeholder={`$${minRaise}`}
+                value={raiseAmount}
+                onChange={e => setRaiseAmount(e.target.value)}
+                disabled={disabled}
+                onKeyDown={e => e.key === 'Enter' && handleRaise()}
+                style={{
+                  width: 100,
+                  padding: '10px 10px',
+                  borderColor: isOverMax ? '#ff4444' : undefined,
+                  outline: isOverMax ? '1px solid #ff4444' : undefined,
+                }}
+              />
+              {isOverMax && (
+                <div style={{ position: 'absolute', top: '100%', left: 0, fontSize: 7, color: '#ff4444', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', marginTop: 2 }}>
+                  Max ${maxRaise}
+                </div>
+              )}
+            </div>
+            <button className="abtn" style={{ fontSize: 14, padding: '4px 12px', lineHeight: 1 }}
+              disabled={disabled} onClick={() => adjustAmount(step)}>
+              ▲
+            </button>
+            <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
+              onClick={() => setStepIdx(i => (i - 1 + STEPS.length) % STEPS.length)}>
+              ◀
+            </button>
+            <div style={{ fontSize: 7, color: 'var(--gold-d)', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', letterSpacing: 1 }}>
+              {step}
+            </div>
+            <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
+              onClick={() => setStepIdx(i => (i + 1) % STEPS.length)}>
+              ▶
+            </button>
+          </div>
+
+          {/* Confirm row */}
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+            <button
+              className="abtn abtn-raise"
+              style={{ flex: 1, maxWidth: 200 }}
+              disabled={disabled || raiseAmount === ''}
+              onClick={handleRaise}
+            >
+              {t('action.raise')} ▲
+            </button>
+          </div>
         </div>
-
-        {/* Increment */}
-        <button className="abtn" style={{ fontSize: 14, padding: '4px 10px', lineHeight: 1 }}
-          disabled={disabled} onClick={() => adjustAmount(step)}>
-          ▲
-        </button>
-
-        {/* Step selector */}
-        <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
-          onClick={() => setStepIdx(i => (i - 1 + STEPS.length) % STEPS.length)}>
-          ◀
-        </button>
-        <div style={{ fontSize: 7, color: 'var(--gold-d)', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', letterSpacing: 1 }}>
-          {t('bet.step')} {step}
-        </div>
-        <button className="abtn" style={{ fontSize: 10, padding: '4px 6px', lineHeight: 1, borderColor: 'var(--gold-d)', color: 'var(--gold-d)' }}
-          onClick={() => setStepIdx(i => (i + 1) % STEPS.length)}>
-          ▶
-        </button>
-
-        {/* Range hint */}
-        <div style={{ fontSize: 7, color: 'var(--gold-d)', fontFamily: 'var(--font-label)', whiteSpace: 'nowrap', letterSpacing: 1 }}>
-          {minRaise}~{maxRaise}
-        </div>
-
-        {/* RAISE confirm */}
-        <button
-          className="abtn abtn-raise"
-          disabled={disabled || raiseAmount === ''}
-          onClick={handleRaise}
-        >
-          {t('action.raise')} ▲<Hint k="R" />
-        </button>
-
-        {/* ALL IN */}
-        <button
-          className="abtn"
-          disabled={disabled}
-          onClick={() => onAction('allin', 0)}
-          style={{ borderColor: '#aa2222', color: '#ff4444', fontSize: 7, padding: '4px 10px', lineHeight: 1.5 }}
-        >
-          {t('action.allin')}<br />${human?.chips}<Hint k="A" />
-        </button>
-
-      </div>
+      )}
 
     </div>
   );

--- a/frontend/src/components/player/PlayerBox.tsx
+++ b/frontend/src/components/player/PlayerBox.tsx
@@ -12,6 +12,7 @@ interface PlayerBoxProps {
   chipBubbleSide: 'right' | 'left';
   badge?: string;   // 'BTN' | 'SB' | 'BB' | 'UTG' | 'HJ' | 'CO'
   winningCards?: CardType[];
+  compact?: boolean; // mobile landscape: smaller box, no speech bubble/chip bubble
 }
 
 function isWinCard(card: CardType, winningCards?: CardType[]): boolean {
@@ -36,6 +37,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   chipBubbleSide,
   badge,
   winningCards,
+  compact = false,
 }) => {
   const { t } = useT();
   const isFolded = !player.is_active;
@@ -47,8 +49,8 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   const boxStyle: React.CSSProperties = {
     background: 'rgba(10, 9, 0, 0.88)',
     border: '2px solid var(--brown)',
-    padding: '10px 14px',
-    width: 260,
+    padding: compact ? '5px 8px' : '10px 14px',
+    width: compact ? 150 : 260,
     clipPath: 'var(--clip-sm)',
     opacity: isFolded ? 0.3 : 1,
     flexShrink: 0,
@@ -63,7 +65,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
   // Show face-up cards only at showdown (cards will be Card objects instead of null)
   const showCards = player.hand.length === 2 && player.hand[0] !== null && player.hand[1] !== null;
-  const hasChipBubble = player.current_bet > 0 && player.is_active;
+  const hasChipBubble = !compact && player.current_bet > 0 && player.is_active;
 
   const bubbleEl = hasChipBubble ? (
     <div style={{
@@ -109,11 +111,11 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
         {badge && (
           <div style={{
             position: 'absolute',
-            top: -14,
+            top: compact ? -11 : -14,
             right: 5,
             background: 'var(--gold)',
             color: '#000',
-            fontSize: 11,
+            fontSize: compact ? 8 : 11,
             padding: '2px 6px',
             fontFamily: 'var(--font-ui)',
             lineHeight: 1.4,
@@ -128,9 +130,9 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
           {/* Bot name */}
           <div style={{
             fontFamily: 'var(--font-ui)',
-            fontSize: 14,
+            fontSize: compact ? 10 : 14,
             color: 'var(--gold)',
-            marginBottom: 4,
+            marginBottom: 3,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -140,9 +142,9 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
           {/* Chips — key replays numUpdate animation when chips change */}
           <div style={{
-            fontSize: 11,
+            fontSize: compact ? 9 : 11,
             color: 'var(--gold-l)',
-            marginBottom: 4,
+            marginBottom: 3,
             fontFamily: 'var(--font-label)',
           }}>
             <span
@@ -155,7 +157,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
 
           {/* Status */}
           <div style={{
-            fontSize: 10,
+            fontSize: compact ? 8 : 10,
             color: status.color,
             fontFamily: 'var(--font-label)',
             display: 'flex',
@@ -178,7 +180,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
           </div>
 
           {/* Cards (face-down or face-up at showdown) */}
-          <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+          <div style={{ display: 'flex', gap: compact ? 3 : 6, marginTop: compact ? 4 : 6 }}>
             {showCards ? (
               <>
                 {[player.hand[0] as CardType, player.hand[1] as CardType].map((card, i) => {
@@ -186,7 +188,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
                   return (
                     <Card
                       key={i}
-                      size="md"
+                      size={compact ? 'sm' : 'md'}
                       variant="face-up"
                       rank={card.rank}
                       suit={card.suit}
@@ -198,14 +200,14 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
               </>
             ) : (
               <>
-                <Card size="md" variant="face-down" />
-                <Card size="md" variant="face-down" />
+                <Card size={compact ? 'sm' : 'md'} variant="face-down" />
+                <Card size={compact ? 'sm' : 'md'} variant="face-down" />
               </>
             )}
           </div>
 
-          {/* Speech bubble — floats outside this box via absolute positioning */}
-          {thought && (
+          {/* Speech bubble — floats outside this box via absolute positioning; hidden in compact mode */}
+          {!compact && thought && (
             <BotSpeechBubble text={thought.chat} side={chipBubbleSide} fading={thought.fading} />
           )}
         </div>

--- a/frontend/src/components/player/PlayerBox.tsx
+++ b/frontend/src/components/player/PlayerBox.tsx
@@ -11,6 +11,11 @@ interface PlayerBoxProps {
   isCurrentTurn: boolean;
   chipBubbleSide: 'right' | 'left';
   badge?: string;   // 'BTN' | 'SB' | 'BB' | 'UTG' | 'HJ' | 'CO'
+  winningCards?: CardType[];
+}
+
+function isWinCard(card: CardType, winningCards?: CardType[]): boolean {
+  return winningCards?.some(wc => wc.rank === card.rank && wc.suit === card.suit) ?? false;
 }
 
 function getStatusText(
@@ -30,6 +35,7 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
   isCurrentTurn,
   chipBubbleSide,
   badge,
+  winningCards,
 }) => {
   const { t } = useT();
   const isFolded = !player.is_active;
@@ -175,18 +181,20 @@ const PlayerBox: React.FC<PlayerBoxProps> = ({
           <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
             {showCards ? (
               <>
-                <Card
-                  size="md"
-                  variant="face-up"
-                  rank={(player.hand[0] as CardType).rank}
-                  suit={(player.hand[0] as CardType).suit}
-                />
-                <Card
-                  size="md"
-                  variant="face-up"
-                  rank={(player.hand[1] as CardType).rank}
-                  suit={(player.hand[1] as CardType).suit}
-                />
+                {[player.hand[0] as CardType, player.hand[1] as CardType].map((card, i) => {
+                  const win = isWinCard(card, winningCards);
+                  return (
+                    <Card
+                      key={i}
+                      size="md"
+                      variant="face-up"
+                      rank={card.rank}
+                      suit={card.suit}
+                      glow={win ? 'win' : 'none'}
+                      style={win ? { animation: 'winCardPulse 1.1s ease-in-out infinite' } : undefined}
+                    />
+                  );
+                })}
               </>
             ) : (
               <>

--- a/frontend/src/components/table/CommunityCards.tsx
+++ b/frontend/src/components/table/CommunityCards.tsx
@@ -4,14 +4,20 @@ import Card from '../card/Card';
 
 interface CommunityCardsProps {
   cards: CardType[];
+  winningCards?: CardType[];
 }
 
-const CommunityCards: React.FC<CommunityCardsProps> = ({ cards }) => {
+function isWinCard(card: CardType, winningCards?: CardType[]): boolean {
+  return winningCards?.some(wc => wc.rank === card.rank && wc.suit === card.suit) ?? false;
+}
+
+const CommunityCards: React.FC<CommunityCardsProps> = ({ cards, winningCards }) => {
   return (
     <div style={{ display: 'flex', gap: 10 }}>
       {Array.from({ length: 5 }, (_, i) => {
         const card = cards[i];
         if (card) {
+          const isWin = isWinCard(card, winningCards);
           // Key changes from 'ph-i' → 'rank-suit' when card is revealed,
           // forcing remount and replaying the cardReveal animation.
           return (
@@ -21,8 +27,12 @@ const CommunityCards: React.FC<CommunityCardsProps> = ({ cards }) => {
               variant="face-up"
               rank={card.rank}
               suit={card.suit}
-              glow="gold"
-              style={{ animation: `cardReveal 0.32s ease-out ${i * 55}ms both` }}
+              glow={isWin ? 'win' : 'gold'}
+              style={{
+                animation: isWin
+                  ? `cardReveal 0.32s ease-out ${i * 55}ms both, winCardPulse 1.1s 0.6s ease-in-out infinite`
+                  : `cardReveal 0.32s ease-out ${i * 55}ms both`,
+              }}
             />
           );
         }

--- a/frontend/src/components/table/HoleCards.tsx
+++ b/frontend/src/components/table/HoleCards.tsx
@@ -7,9 +7,14 @@ interface HoleCardsProps {
   cards: (CardType | null)[];
   isHumanTurn: boolean; // Fix 7: show red glow only when it's the human's turn to act
   handCount: number;    // Changes every new hand → triggers re-animation via key
+  winningCards?: CardType[];
 }
 
-const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn, handCount }) => {
+function isWinCard(card: CardType, winningCards?: CardType[]): boolean {
+  return winningCards?.some(wc => wc.rank === card.rank && wc.suit === card.suit) ?? false;
+}
+
+const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn, handCount, winningCards }) => {
   const { t } = useT();
   return (
     <div style={{
@@ -36,21 +41,25 @@ const HoleCards: React.FC<HoleCardsProps> = ({ cards, isHumanTurn, handCount }) 
 
       {/* Two hole cards */}
       <div style={{ display: 'flex', gap: 12 }}>
-        {cards.slice(0, 2).map((card, i) =>
-          card ? (
+        {cards.slice(0, 2).map((card, i) => {
+          if (!card) return <Card key={`${handCount}-${i}`} size="md" variant="face-down" />;
+          const win = isWinCard(card, winningCards);
+          return (
             <Card
               key={`${handCount}-${i}`}
               size="md"
               variant="face-up"
               rank={card.rank}
               suit={card.suit}
-              glow={isHumanTurn ? 'red' : 'none'}
-              style={{ animation: `cardDeal 0.4s ease-out ${i * 110}ms both` }}
+              glow={win ? 'win' : isHumanTurn ? 'red' : 'none'}
+              style={{
+                animation: win
+                  ? `cardDeal 0.4s ease-out ${i * 110}ms both, winCardPulse 1.1s 0.6s ease-in-out infinite`
+                  : `cardDeal 0.4s ease-out ${i * 110}ms both`,
+              }}
             />
-          ) : (
-            <Card key={`${handCount}-${i}`} size="md" variant="face-down" />
-          )
-        )}
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -35,7 +35,10 @@ function getBadge(
 
 const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
   const { t } = useT();
-  const { players, community_cards, pot, state, current_player_idx } = gameState;
+  const { players, community_cards, pot, state, current_player_idx, winning_cards } = gameState;
+
+  // At a real showdown (not fold-out), we have winning_cards to highlight
+  const isActualShowdown = (state === 'SHOWDOWN' || state === 'FINISHED') && winning_cards.length > 0;
 
   // players[0] = human; bots = players[1..5]
   const humanPlayer = players[0];
@@ -145,6 +148,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                   isCurrentTurn={current_player_idx === playerIdx}
                   chipBubbleSide="right"
                   badge={getBadge(playerIdx, effectiveDealerIdx, totalPlayers)}
+                  winningCards={isActualShowdown && gameState.winners.includes(bot.id) ? winning_cards : undefined}
                 />
               );
             })}
@@ -169,6 +173,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                   isCurrentTurn={current_player_idx === playerIdx}
                   chipBubbleSide="left"
                   badge={getBadge(playerIdx, effectiveDealerIdx, totalPlayers)}
+                  winningCards={isActualShowdown && gameState.winners.includes(bot.id) ? winning_cards : undefined}
                 />
               );
             })}
@@ -186,7 +191,10 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
             gap: 12,
           }}>
             <PotDisplay pot={pot} street={state} />
-            <CommunityCards cards={community_cards} />
+            <CommunityCards
+              cards={community_cards}
+              winningCards={isActualShowdown ? winning_cards : undefined}
+            />
           </div>
 
           {/* Human hole cards (bottom center) */}
@@ -199,6 +207,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                 state !== 'SHOWDOWN' &&
                 state !== 'FINISHED'
               }
+              winningCards={isActualShowdown && gameState.winners.includes(humanPlayer.id) ? winning_cards : undefined}
             />
           )}
 
@@ -249,6 +258,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                 clipPath: 'var(--clip-md)',
                 zIndex: 10,
                 whiteSpace: 'nowrap',
+                animation: 'showdownReveal 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) forwards',
               }}>
                 <div style={{ fontSize: 7, color: 'var(--gold-d)', letterSpacing: 3, marginBottom: 8, fontFamily: 'var(--font-label)' }}>
                   {t('showdown.label')}

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -9,6 +9,7 @@ import DealerBadge from './DealerBadge';
 import ActionAnnouncement from './ActionAnnouncement';
 import { useGameStore } from '../../store/useGameStore';
 import { useT } from '../../i18n/I18nContext';
+import { useIsMobile } from '../../hooks/useIsMobile';
 
 interface PokerTableProps {
   gameState: GameState;
@@ -35,6 +36,7 @@ function getBadge(
 
 const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
   const { t } = useT();
+  const isMobile = useIsMobile();
   const { players, community_cards, pot, state, current_player_idx, winning_cards } = gameState;
 
   // At a real showdown (not fold-out), we have winning_cards to highlight
@@ -142,11 +144,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
           {/* Left bots (3) */}
           <div style={{
             position: 'absolute',
-            left: 16,
-            top: 28,
+            left: isMobile ? 6 : 16,
+            top: isMobile ? 16 : 28,
             display: 'flex',
             flexDirection: 'column',
-            gap: 20,
+            gap: isMobile ? 6 : 20,
           }}>
             {leftBots.map((bot, i) => {
               const playerIdx = i + 1; // bot 0→idx1, bot 1→idx2, bot 2→idx3
@@ -158,6 +160,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                   chipBubbleSide="right"
                   badge={getBadge(playerIdx, effectiveDealerIdx, totalPlayers)}
                   winningCards={isActualShowdown && gameState.winners.includes(bot.id) ? winning_cards : undefined}
+                  compact={isMobile}
                 />
               );
             })}
@@ -166,11 +169,11 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
           {/* Right bots (2) */}
           <div style={{
             position: 'absolute',
-            right: 16,
-            top: 28,
+            right: isMobile ? 6 : 16,
+            top: isMobile ? 16 : 28,
             display: 'flex',
             flexDirection: 'column',
-            gap: 20,
+            gap: isMobile ? 6 : 20,
             alignItems: 'flex-end',
           }}>
             {rightBots.map((bot, i) => {
@@ -183,6 +186,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                   chipBubbleSide="left"
                   badge={getBadge(playerIdx, effectiveDealerIdx, totalPlayers)}
                   winningCards={isActualShowdown && gameState.winners.includes(bot.id) ? winning_cards : undefined}
+                  compact={isMobile}
                 />
               );
             })}
@@ -220,8 +224,8 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
           {humanPlayer && (
             <div style={{
               position: 'absolute',
-              bottom: 20,
-              left: 'calc(50% + 90px)',
+              bottom: isMobile ? 10 : 20,
+              left: isMobile ? 'calc(50% + 68px)' : 'calc(50% + 90px)',
             }}>
               <HumanPanel
                 player={humanPlayer}

--- a/frontend/src/components/table/PokerTable.tsx
+++ b/frontend/src/components/table/PokerTable.tsx
@@ -56,6 +56,15 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
 
   // Floating action announcement from store
   const currentAction = useGameStore(s => s.currentAction);
+  // actionInFlight: human sent an action but server hasn't responded yet
+  const actionInFlight = useGameStore(s => s.actionInFlight);
+
+  // isActiveHumanTurn: true only while human must still act (stops blink immediately on click)
+  const isActiveHumanTurn =
+    current_player_idx === 0 &&
+    state !== 'SHOWDOWN' &&
+    state !== 'FINISHED' &&
+    !actionInFlight;
 
   // Track dealing/revealing state for DealerBadge
   const [isDealing, setIsDealing] = React.useState(false);
@@ -202,11 +211,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
             <HoleCards
               cards={humanPlayer.hand}
               handCount={handCount}
-              isHumanTurn={
-                current_player_idx === 0 &&
-                state !== 'SHOWDOWN' &&
-                state !== 'FINISHED'
-              }
+              isHumanTurn={isActiveHumanTurn}
               winningCards={isActualShowdown && gameState.winners.includes(humanPlayer.id) ? winning_cards : undefined}
             />
           )}
@@ -223,11 +228,7 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
                 dealerIdx={effectiveDealerIdx}
                 playerIdx={0}
                 totalPlayers={totalPlayers}
-                isHumanTurn={
-                  current_player_idx === 0 &&
-                  state !== 'SHOWDOWN' &&
-                  state !== 'FINISHED'
-                }
+                isHumanTurn={isActiveHumanTurn}
               />
             </div>
           )}
@@ -246,7 +247,9 @@ const PokerTable: React.FC<PokerTableProps> = ({ gameState, handCount }) => {
               .map(id => players.find(p => p.id === id)?.name ?? id)
               .join(' & ');
             return (
-              <div style={{
+              <div
+                key={gameState.winners.join('-')}
+                style={{
                 position: 'absolute',
                 top: '30%',
                 left: '50%',

--- a/frontend/src/components/table/PotDisplay.tsx
+++ b/frontend/src/components/table/PotDisplay.tsx
@@ -9,19 +9,31 @@ interface PotDisplayProps {
 
 const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
   const { t } = useT();
-  // Track whether the pot just grew so we can apply the glow animation
   const prevPot = useRef(pot);
   const [glowing, setGlowing] = useState(false);
+  // When pot drops to 0 (winner awarded), briefly show old value with chipCollect animation
+  const [collecting, setCollecting] = useState(false);
+  const [collectingAmount, setCollectingAmount] = useState(0);
 
   useEffect(() => {
+    if (pot === 0 && prevPot.current > 0) {
+      // Pot was just awarded — animate chips flying away before disappearing
+      setCollectingAmount(prevPot.current);
+      setCollecting(true);
+      const timer = setTimeout(() => setCollecting(false), 550);
+      prevPot.current = 0;
+      return () => clearTimeout(timer);
+    }
     if (pot > prevPot.current) {
       setGlowing(true);
-      const t = setTimeout(() => setGlowing(false), 600);
+      const timer = setTimeout(() => setGlowing(false), 600);
       prevPot.current = pot;
-      return () => clearTimeout(t);
+      return () => clearTimeout(timer);
     }
     prevPot.current = pot;
   }, [pot]);
+
+  const displayPot = collecting ? collectingAmount : pot;
 
   return (
     <div style={{ textAlign: 'center' }}>
@@ -36,21 +48,23 @@ const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
         {street}
       </div>
 
-      {/* Chip stack visual — key forces remount+animation on every pot change */}
+      {/* Chip stack visual */}
       <div
         style={{
           display: 'flex',
           justifyContent: 'center',
           marginBottom: 8,
-          minHeight: 40,        // reserve space so layout doesn't jump at 0
+          minHeight: 40,
           alignItems: 'flex-end',
-          animation: glowing ? 'chipGlow 0.6s ease-out' : 'none',
+          animation: collecting
+            ? 'chipCollect 0.5s ease-in forwards'
+            : glowing ? 'chipGlow 0.6s ease-out' : 'none',
         }}
       >
-        <ChipStack key={pot} amount={pot} size="md" />
+        <ChipStack key={displayPot} amount={displayPot} size="md" />
       </div>
 
-      {/* Pot amount text */}
+      {/* Pot amount text — fades out during collection */}
       <div style={{
         fontSize: 10,
         color: 'var(--gold-l)',
@@ -58,6 +72,8 @@ const PotDisplay: React.FC<PotDisplayProps> = ({ pot, street }) => {
         textShadow: '0 0 6px var(--gold)',
         fontFamily: 'var(--font-label)',
         whiteSpace: 'nowrap',
+        opacity: collecting ? 0 : 1,
+        transition: collecting ? 'opacity 0.3s ease' : 'none',
       }}>
         {t('pot.label')}{' '}
         <span

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns true when the viewport is a landscape mobile screen (height < 500px).
+ * Desktop monitors and tablets (height >= 500px) always return false,
+ * guaranteeing zero impact on the existing desktop experience.
+ */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => window.innerHeight < 500);
+
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerHeight < 500);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  return isMobile;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -184,6 +184,31 @@
   100% { opacity: 1; transform: translateX(-50%) scale(1); }
 }
 
+/* === Mobile landscape: safe area padding === */
+@media (max-width: 767px) and (orientation: landscape) {
+  body {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
+/* === Portrait rotation prompt === */
+.portrait-overlay {
+  display: none;
+}
+
+@media (max-width: 767px) and (orientation: portrait) {
+  .portrait-overlay {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.92);
+    z-index: 9000;
+  }
+}
+
 /* Hide native number input spinners (Part 1) */
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button { display: none; }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -171,6 +171,19 @@
   to { transform: rotate(360deg); }
 }
 
+/* Winning hand cards — pulsing teal/cyan glow */
+@keyframes winCardPulse {
+  0%, 100% { box-shadow: 4px 4px 0 #000, 0 0 10px rgba(0, 220, 160, 0.45); }
+  50%       { box-shadow: 4px 4px 0 #000, 0 0 28px rgba(0, 220, 160, 0.95), 0 0 50px rgba(0, 220, 160, 0.35); }
+}
+
+/* Showdown winner banner — dramatic scale pop entrance */
+@keyframes showdownReveal {
+  0%   { opacity: 0; transform: translateX(-50%) scale(0.4); }
+  55%  { opacity: 1; transform: translateX(-50%) scale(1.08); }
+  100% { opacity: 1; transform: translateX(-50%) scale(1); }
+}
+
 /* Hide native number input spinners (Part 1) */
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button { display: none; }

--- a/frontend/src/store/useGameStore.ts
+++ b/frontend/src/store/useGameStore.ts
@@ -52,6 +52,9 @@ interface GameStore {
   // Floating action announcement
   currentAction: PlayerAction | null;
 
+  // Action in-flight: true from sendAction until server responds (prevents double-click + stops blink)
+  actionInFlight: boolean;
+
   // Game over
   isGameOver: boolean;
   gameOverReason: string | null;
@@ -80,6 +83,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   errorMessage: null,
   handCount: 0,
   currentAction: null,
+  actionInFlight: false,
   isGameOver: false,
   gameOverReason: null,
   coachAdvice: null,
@@ -146,6 +150,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       set(state => ({
         gameState: data,
         handCount: isNewHand ? state.handCount + 1 : state.handCount,
+        actionInFlight: false,  // server responded → clear in-flight lock
       }));
     });
 
@@ -260,7 +265,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
         action: action as PlayerAction['action'],
         amount,
       };
-      set({ currentAction: humanAction });
+      set({ currentAction: humanAction, actionInFlight: true });
       setTimeout(() => {
         set(state => {
           if (state.currentAction === humanAction) return { currentAction: null };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,7 @@ export interface GameState {
   min_raise: number;
   winners: string[];
   winning_hand: string;
+  winning_cards: Card[];
   can_raise: boolean;
   raise_count: number;
   max_raises_per_street: number;


### PR DESCRIPTION
## Summary
This PR introduces mobile landscape support with a responsive action bar, implements a personality-based modifier system for the GTO bot strategy, and adds showdown card highlighting with winner announcement. The changes improve UX across device sizes while maintaining the existing desktop experience.

## Key Changes

### Frontend: Mobile Landscape Support
- **ActionBar responsiveness**: Added `useIsMobile()` hook (height < 500px detection) to conditionally render:
  - Mobile: Simplified raise button + all-in button, with a bottom sheet modal for detailed raise controls
  - Desktop: Full raise controls with quick-bet buttons, step adjusters, and range display
- **PlayerBox compaction**: Added `compact` prop to reduce padding, width, and font sizes on mobile
- **PokerTable layout**: Adjusted spacing and positioning for mobile (reduced gaps, repositioned player boxes)
- **Portrait rotation prompt**: Added CSS-driven overlay (`portrait-overlay`) that displays only in portrait orientation on mobile
- **Disconnect overlay**: Added visual feedback when socket connection is lost during gameplay

### Frontend: Showdown & Card Highlighting
- **Winning cards display**: Added `winning_cards` prop to HoleCards, CommunityCards, and PlayerBox components
- **Card glow animation**: New `winCardPulse` keyframe animation (teal/cyan glow) for cards in the winning hand
- **PotDisplay animation**: Added `chipCollect` animation when pot is awarded (chips fly away before pot resets to 0)
- **Showdown reveal animation**: New `showdownReveal` keyframe for winner banner entrance

### Backend: GTO Personality System
- **Personality modifiers**: Introduced `_PersonalityMod` dataclass with four tunable parameters:
  - `open_freq_mult`: Range width multiplier (maniac=1.4, rock=0.7)
  - `value_thresh_offset`: Equity threshold adjustment (maniac=-0.12, rock=+0.06)
  - `call_margin_offset`: Call margin adjustment (station=-0.18, maniac=-0.12)
  - `bluff_freq_mult`: Bluff frequency multiplier (maniac=2.5, rock=0.2)
- **Five personalities**: shark (balanced GTO+), rock (tight), maniac (aggressive), station (loose-passive), tag (tight-aggressive)
- **GTOBotStrategy refactor**: Constructor now accepts personality parameter; `decide()` applies modifiers to preflop ranges and postflop thresholds
- **Preflop logic fix**: Corrected `raise_count` usage to distinguish open-raise opportunities (raise_count==0) from facing actual raises
- **Chat integration**: Replaced hardcoded `_CHAT` dict with personality-aware `_personality_chat()` function

### Backend: Game Engine Improvements
- **Dealer rotation fix**: `start_hand()` now skips eliminated players (chips==0) when rotating dealer button
- **Blind assignment fix**: SB and BB calculation now skips inactive players to ensure correct positioning
- **Winning cards tracking**: Added `winning_cards: List[Card]` field to engine; new `HandEvaluator.best_five()` method returns the 5 cards forming the best hand
- **Test updates**: Updated `test_scenario_12_player_elimination_across_hands()` to reflect corrected dealer/blind logic

### Frontend: State & Action Management
- **actionInFlight flag**: Added to GameStore to track when human has sent an action but server hasn't responded
- **ActionBar disable logic**: Buttons now disabled when `actionInFlight` is true (prevents double-click)
- **Turn indicator**: Blink animation stops immediately when action is sent (no longer waits for server response)

### Type System
- **GameState interface**: Added `winning_cards: Card[]` field
- **Card component**: Updated glow type to support 'win' variant for showdown highlighting

## Notable Implementation Details
- Mobile detection uses `window.innerHeight < 500px` to target landscape phones while preserving desktop/tablet experience
- Bottom sheet modal for mobile raise controls uses `position: fixed` with `env(safe-area-inset-bottom)` for notch/home indicator safety
- Personality mod

https://claude.ai/code/session_01SchZuUtaeqcETb6W3zq9GC