### PR TITLE
fix(docker): Python 3.9 startup crash — /start-game union annotation

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -525,7 +525,7 @@ def _setup_new_tournament(req: StartGameRequest) -> None:
 
 
 @app.post('/start-game')
-async def start_game(config: StartGameRequest | None = None) -> dict[str, str]:
+async def start_game(config: Optional[StartGameRequest] = None) -> dict[str, str]:
     _setup_new_tournament(config or StartGameRequest())
     _prepare_hand()
     engine.start_hand()


### PR DESCRIPTION
## 问题

`docker-compose up --build` 时 frontend 容器报 `unhealthy` 启动失败。

## 根因

frontend 通过 `depends_on: backend: condition: service_healthy` 硬依赖 backend 健康。而 backend 容器是 **Python 3.9-slim**，新加的 `/start-game` 端点签名用了 PEP 604 联合类型：

```python
async def start_game(config: StartGameRequest | None = None):
```

FastAPI 启动时会用 `get_type_hints()` 内省端点参数注解——**这一步会真正求值类型表达式，`from __future__ import annotations` 不生效**。`X | None` 是 Python 3.10+ 语法，在 3.9 上抛 `TypeError` → uvicorn 启动失败 → backend healthcheck 永不通过 → frontend 判定依赖 unhealthy → 整个栈起不来。

(本地 Python 3.11 能正常跑，所以之前没暴露。)

## 修复

改用 `Optional[StartGameRequest]`，3.9 可正常求值。其余模块级变量注解 / 辅助函数返回注解里的 `|` 联合都被 future-import 延迟为字符串、且不被 FastAPI 内省，因此不受影响。

## 验证
- 模拟 FastAPI 启动内省（`get_type_hints` 各端点）通过。
- `app` + `socket_app` 路由构建成功。
- 后端 140 测试全过。

https://claude.ai/code/session_01Lu9fLb1iipoYDuxCVc2P8t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lu9fLb1iipoYDuxCVc2P8t)_